### PR TITLE
chore(CI, packaging): Replace yarn

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,7 +13,6 @@ generated
 __tests__
 
 # package managers
-yarn-error.log
 lerna-debug.log
 
 # IDEs and editors

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -18,24 +18,24 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: yarn-cache
+        id: npm-cache
         name: Cache npm deps
         with:
           path: |
            node_modules
            **/node_modules
-          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-npm-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - run: npm install --frozen-lockfile
+        if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
         id: dist
         name: Cache dist
         with:
           path: |
             packages/*/dist
-          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
+          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
-        run: yarn build
+        run: npm run build
         if: steps.dist.outputs.cache-hit != 'true'
   lint:
     runs-on: ubuntu-latest
@@ -54,25 +54,25 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: yarn-cache
+        id: npm-cache
         name: Cache npm deps
         with:
           path: |
            node_modules
            **/node_modules
-          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - run: npm install --frozen-lockfile
+        if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
         id: lint-cache
         name: Load lint cache
         with:
           path: '.eslintcache'
-          key: ${{ runner.os }}-lint-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-lint-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: ESLint
-        run: yarn lint:js
+        run: npm run lint:js
       - name: MDLint
-        run: yarn lint:md
+        run: npm run lint:md
   test_jest:
     runs-on: ubuntu-latest
     env:
@@ -91,16 +91,16 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: yarn-cache
+        id: npm-cache
         name: Cache npm deps
         with:
           path: |
            node_modules
            **/node_modules
            ~/.cache/Cypress
-          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - run: npm install --frozen-lockfile
+        if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
         id: dist
         name: Cache dist
@@ -108,12 +108,12 @@ jobs:
           path: |
             packages/*/dist
             packages/react-styles/css
-          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
+          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
-        run: yarn build
+        run: npm run build
         if: steps.dist.outputs.cache-hit != 'true'
       - name: PF4 Jest Tests
-        run: yarn test --maxWorkers=2
+        run: npm run test --maxWorkers=2
   test_a11y:
     runs-on: ubuntu-latest
     env:
@@ -132,16 +132,16 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: yarn-cache
+        id: npm-cache
         name: Cache npm deps
         with:
           path: |
            node_modules
            **/node_modules
            ~/.cache/Cypress
-          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - run: npm install --frozen-lockfile
+        if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
         id: dist
         name: Cache dist
@@ -149,11 +149,11 @@ jobs:
           path: |
             packages/*/dist
             packages/react-styles/css
-          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
+          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
-        run: yarn build
+        run: npm run build
         if: steps.dist.outputs.cache-hit != 'true'
       - name: Build docs
-        run: yarn build:docs
+        run: npm run build:docs
       - name: A11y tests
-        run: yarn serve:docs & yarn test:a11y
+        run: npm run serve:docs & npm run test:a11y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,22 +34,22 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: yarn-cache
+        id: npm-cache
         name: Cache npm deps
         with:
           path: |
            node_modules
            **/node_modules
-          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - run: npm install --frozen-lockfile
+        if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
         id: dist
         name: Cache dist
         with:
           path: |
             packages/*/dist
-          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
+          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
-        run: yarn build
+        run: npm run build
         if: steps.dist.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,16 @@ jobs:
         with:
           node-version: '16'
       - uses: actions/cache@v2
-        id: yarn-cache
+        id: npm-cache
         name: Cache npm deps
         with:
           path: |
            node_modules
            **/node_modules
            ~/.cache/Cypress
-          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-yarn-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - run: npm install --frozen-lockfile
+        if: steps.npm-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
         id: dist
         name: Cache dist
@@ -35,9 +35,9 @@ jobs:
           path: |
             packages/*/dist
             packages/react-styles/css
-          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
+          key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('package-lock.json', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
-        run: yarn build
+        run: npm run build
         if: steps.dist.outputs.cache-hit != 'true'
       - name: Release to NPM
         run: cd packages/module && npx semantic-release@19.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ coverage
 generated
 
 # package managers
-yarn-error.log
 lerna-debug.log
 
 # IDEs and editors

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,7 +12,6 @@ coverage
 generated
 
 # package managers
-yarn-error.log
 lerna-debug.log
 
 # IDEs and editors

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ This repo contains a set of opinionated react component groups used to standardi
 
 ## Building for production
 
-- run yarn install
-- run yarn build
+- run npm install
+- run npm run build
 
 ## Development
-- run yarn install
-- run yarn start to build and start the development server
+- run npm install
+- run npm run start to build and start the development server
 
 ## Testing and Linting
-- run yarn test to run the tests for the demo component
-- run yarn lint to run the linter
+- run npm run test to run the tests for the demo component
+- run npm run lint to run the linter
 
 ## A11y testing
 
-- run yarn build:docs followed by yarn serve:docs, then run yarn test:a11y in a new terminal window to run our accessibility tests for the components. Once the accessibility tests have finished running you can run yarn 
-- serve:a11y to locally view the generated report.
+- run npm run build:docs followed by npm run serve:docs, then run npm run test:a11y in a new terminal window to run our accessibility tests for the components. Once the accessibility tests have finished running you can run 
+- npm run serve:a11y to locally view the generated report.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3403,38 +3403,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@patternfly/documentation-framework/node_modules/@reach/router": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
-      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "create-react-context": "0.3.0",
-        "invariant": "^2.2.3",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": "15.x || 16.x || 16.4.0-alpha.0911da3",
-        "react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
-      }
-    },
-    "node_modules/@patternfly/documentation-framework/node_modules/@reach/router/node_modules/create-react-context": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@patternfly/documentation-framework/node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.3.tgz",
@@ -3811,6 +3779,36 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz",
       "integrity": "sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw==",
       "license": "MIT"
+    },
+    "node_modules/@reach/router": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
+      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
+      "dev": true,
+      "dependencies": {
+        "create-react-context": "0.3.0",
+        "invariant": "^2.2.3",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 16.4.0-alpha.0911da3",
+        "react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
+      }
+    },
+    "node_modules/@reach/router/node_modules/create-react-context": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+      "dev": true,
+      "dependencies": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.0.0",
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+      }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
       "version": "3.3.11",
@@ -13180,8 +13178,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/gzip-size": {
       "version": "5.1.1",
@@ -29957,6 +29954,7 @@
         "@patternfly/patternfly-a11y": "4.3.1",
         "@patternfly/react-code-editor": "^4.82.26",
         "@patternfly/react-table": "^4.111.4",
+        "@reach/router": "1.3.4",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
@@ -32278,30 +32276,6 @@
             "semver": "^6.3.0"
           }
         },
-        "@reach/router": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
-          "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-          "dev": true,
-          "requires": {
-            "create-react-context": "0.3.0",
-            "invariant": "^2.2.3",
-            "prop-types": "^15.6.1",
-            "react-lifecycles-compat": "^3.0.4"
-          },
-          "dependencies": {
-            "create-react-context": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-              "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-              "dev": true,
-              "requires": {
-                "gud": "^1.0.0",
-                "warning": "^4.0.3"
-              }
-            }
-          }
-        },
         "babel-plugin-polyfill-corejs3": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.3.tgz",
@@ -32533,6 +32507,7 @@
         "@patternfly/react-code-editor": "^4.82.26",
         "@patternfly/react-core": "^4.250.1",
         "@patternfly/react-table": "^4.111.4",
+        "@reach/router": "1.3.4",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
@@ -32599,6 +32574,30 @@
       "version": "4.93.6",
       "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz",
       "integrity": "sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw=="
+    },
+    "@reach/router": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
+      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
+      "dev": true,
+      "requires": {
+        "create-react-context": "0.3.0",
+        "invariant": "^2.2.3",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "create-react-context": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+          "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+          "dev": true,
+          "requires": {
+            "gud": "^1.0.0",
+            "warning": "^4.0.3"
+          }
+        }
+      }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
       "version": "3.3.11",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -16,7 +16,7 @@
     "docs:serve": "pf-docs-framework serve public --port 5000",
     "docs:screenshots": "pf-docs-framework screenshots --urlPrefix http://localhost:5000",
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config",
-    "serve:a11y": "yarn serve coverage"
+    "serve:a11y": "npm run serve coverage"
   },
   "repository": "git+https://github.com/patternfly/react-component-groups.git",
   "author": "Red Hat",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -16,7 +16,7 @@
     "docs:serve": "pf-docs-framework serve public --port 5000",
     "docs:screenshots": "pf-docs-framework screenshots --urlPrefix http://localhost:5000",
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config",
-    "serve:a11y": "npm run serve coverage"
+    "serve:a11y": "serve coverage"
   },
   "repository": "git+https://github.com/patternfly/react-component-groups.git",
   "author": "Red Hat",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -2,7 +2,7 @@
   "name": "@patternfly/react-component-groups",
   "version": "1.0.0",
   "description": "Extended components used for Red Hat projects.",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "scripts": {
     "build": "npm run build:js && npm run build:esm && npm run build:fed:packages",
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@patternfly/documentation-framework": "^1.2.55",
+    "@reach/router": "1.3.4",
     "@patternfly/patternfly": "^4.217.1",
     "@patternfly/patternfly-a11y": "4.3.1",
     "@patternfly/react-code-editor": "^4.82.26",


### PR DESCRIPTION
Completes the move from yarn to just npm, also resolves a reach/router error that I was encountering when attempting to build the docs.

I think this issue stems from a difference in how npm and yarn resolve dependency issues, and that the issue will likely be resolved on its own after switching to the latest (currently alpha) version of the documentation framework. In the meantime adding reach/router as a devDep and initially doing a force install seemed to work around the issue.