### PR TITLE
Remove tab contents wrapper

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/DetailsPage/DetailsPageExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/DetailsPage/DetailsPageExample.tsx
@@ -51,8 +51,8 @@ export const BasicExample: React.FunctionComponent = () => (
         id: 'details-page-action-menu-example'
       }}
       tabs={[
-        { eventKey: 'details', title: 'Details', children: <div>Details content</div> },
-        { eventKey: 'other', title: 'Other', children: <div>Other content</div> }
+        { eventKey: 'details', title: 'Details', children: <div className="pf-u-m-md">Details content</div> },
+        { eventKey: 'other', title: 'Other', children: <div className="pf-u-m-md">Other content</div> }
       ]}
     />
   </Router>

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/DetailsPage/HorizontalNavExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/DetailsPage/HorizontalNavExample.tsx
@@ -4,8 +4,8 @@ import { HorizontalNav } from '@patternfly/react-component-groups';
 export const BasicExample: React.FunctionComponent = () => (
   <HorizontalNav
     tabs={[
-      { eventKey: 'details', title: 'Details', children: <div>Details children</div> },
-      { eventKey: 'other', title: 'Other', children: <div>Other content</div> }
+      { eventKey: 'details', title: 'Details', children: <div className="pf-u-m-md">Details content</div> },
+      { eventKey: 'other', title: 'Other', children: <div className="pf-u-m-md">Other content</div> }
     ]}
   />
 );

--- a/packages/module/src/HorizontalNav/HorizontalNav.tsx
+++ b/packages/module/src/HorizontalNav/HorizontalNav.tsx
@@ -69,7 +69,7 @@ export const HorizontalNav: React.FunctionComponent<HorizontalNavProps> = ({
           ouiaId={tab?.ouiaId}
           key={tab.eventKey}
         >
-          <div className="pf-u-m-md">{tab.children}</div>
+          {tab.children}
         </Tab>
       ))}
     </Tabs>


### PR DESCRIPTION
Allow the children of the tab to control the spacing so as to maintain consistency with PatternFly.