### PR TITLE
Remove setState call from ErrorBoundary render fn

### DIFF
--- a/packages/module/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/module/src/ErrorBoundary/ErrorBoundary.tsx
@@ -41,15 +41,24 @@ class ErrorBoundary extends React.Component<React.PropsWithChildren<ErrorPagePro
     return { hasError: true, error, historyState: history.state };
   }
 
-  render() {
-
+  updateState = () => {
     if (this.state.historyState !== history.state) {
       this.setState({
         hasError: false,
         historyState: history.state,
       });
     }
+  };
 
+  componentDidUpdate(): void {
+    this.updateState();
+  }
+
+  componentDidMount(): void {
+    this.updateState();
+  }
+
+  render() {
     if (this.state.hasError) {
       if (this.props.silent) {
         return null;


### PR DESCRIPTION
This adds https://github.com/RedHatInsights/frontend-components/pull/1901