### PR TITLE
Minor fixes and enhancements for FEC compatibility

### DIFF
--- a/packages/module/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/module/src/ErrorBoundary/ErrorBoundary.tsx
@@ -4,7 +4,7 @@ import ErrorState from '../ErrorState';
 import ErrorStack from '../ErrorStack';
 
 export interface ErrorPageProps {
-  /** The title to display on the error page */
+  /** Title to display on the error page */
   headerTitle: string;
   /** Indicates if this is a silent error */
   silent?: boolean;

--- a/packages/module/src/ErrorStack/ErrorStack.tsx
+++ b/packages/module/src/ErrorStack/ErrorStack.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
+import clsx from 'clsx';
 import { Text } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
 
 export interface ErrorStackProps {
+  /** Error object to be displayed in the stack */
   error: Error;
+  /** Custom className */
+  className?: string;
 }
 
 const useStyles = createUseStyles({
@@ -19,11 +23,12 @@ const useStyles = createUseStyles({
   },
 })
 
-export const ErrorStack: React.FunctionComponent<ErrorStackProps> = ({ error }) => {
+export const ErrorStack: React.FunctionComponent<ErrorStackProps> = ({ error, className, ...props }) => {
   const classes = useStyles();
+
   if (error.stack) {
     return (
-      <Text className={classes.errorStack}>
+      <Text className={clsx(classes.errorStack, className)} {...props} >
         {error.stack.split('\n').map((line) => (
           <div key={line}>{line}</div>
         ))}
@@ -35,7 +40,7 @@ export const ErrorStack: React.FunctionComponent<ErrorStackProps> = ({ error }) 
     return (
       <>
         <Text component="h6">{error.name}</Text>
-        <Text className={classes.errorStack} component="blockquote">
+        <Text className={clsx(classes.errorStack, className)} component="blockquote" {...props}>
           {error.message}
         </Text>
       </>

--- a/packages/module/src/NotAuthorized/NotAuthorized.tsx
+++ b/packages/module/src/NotAuthorized/NotAuthorized.tsx
@@ -17,7 +17,7 @@ export interface NotAuthorizedProps extends Omit<EmptyStateProps, 'children' | '
   className?: string;
   /** Custom title */
   title?: React.ReactNode;
-  /** Custom primary action there should only be one primary action*/
+  /** Custom primary action - there should only be one defined */
   primaryAction?: React.ReactNode;
   /** Custom secondary actions */
   secondaryActions?: React.ReactNode;

--- a/packages/module/src/SkeletonTable/index.ts
+++ b/packages/module/src/SkeletonTable/index.ts
@@ -1,2 +1,2 @@
 export { default } from './SkeletonTable';
-export { default as SkeletonTable } from './SkeletonTable';
+export * from './SkeletonTable';

--- a/packages/module/src/TagCount/TagCount.tsx
+++ b/packages/module/src/TagCount/TagCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import { Button, ButtonProps, Icon } from '@patternfly/react-core';
+import { BaseSizes, Button, ButtonProps, Icon, IconComponentProps, IconProps } from '@patternfly/react-core';
 import { TagIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss'
 
@@ -21,17 +21,20 @@ export interface TagCountProps extends ButtonProps {
   count?: number;
   /** Additional classes added to the tag count component */
   className?: string;
+  /** Icon size */
+  iconSize?: 'sm' | 'md' | 'lg' | 'xl';
 }
 
 const TagCount: React.FunctionComponent<TagCountProps> = (
   { count, 
     className,
+    iconSize= 'md',
     ...props }: TagCountProps) => {
   const classes = useStyles();
   const tagClasses = clsx(classes.buttonTagCount, className);
   return (
     <Button aria-label="Tag count" {...props} variant="plain" isDisabled={!count} className={tagClasses}>
-      <Icon size="md">
+      <Icon iconSize={iconSize} >
         <TagIcon/>
       </Icon>
       <span className={classes.tagText}>{count}</span>

--- a/packages/module/src/TagCount/TagCount.tsx
+++ b/packages/module/src/TagCount/TagCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import { BaseSizes, Button, ButtonProps, Icon, IconComponentProps, IconProps } from '@patternfly/react-core';
+import { Button, ButtonProps, Icon } from '@patternfly/react-core';
 import { TagIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss'
 

--- a/packages/module/src/TagCount/__snapshots__/TagCount.test.tsx.snap
+++ b/packages/module/src/TagCount/__snapshots__/TagCount.test.tsx.snap
@@ -16,10 +16,10 @@ exports[`TagCount component should render a disabled tag count with no value 1`]
         type="button"
       >
         <span
-          class="pf-v5-c-icon pf-m-md"
+          class="pf-v5-c-icon"
         >
           <span
-            class="pf-v5-c-icon__content"
+            class="pf-v5-c-icon__content pf-m-md"
           >
             <svg
               aria-hidden="true"
@@ -54,10 +54,10 @@ exports[`TagCount component should render a disabled tag count with no value 1`]
       type="button"
     >
       <span
-        class="pf-v5-c-icon pf-m-md"
+        class="pf-v5-c-icon"
       >
         <span
-          class="pf-v5-c-icon__content"
+          class="pf-v5-c-icon__content pf-m-md"
         >
           <svg
             aria-hidden="true"
@@ -148,10 +148,10 @@ exports[`TagCount component should render a tag count of 11 1`] = `
         type="button"
       >
         <span
-          class="pf-v5-c-icon pf-m-md"
+          class="pf-v5-c-icon"
         >
           <span
-            class="pf-v5-c-icon__content"
+            class="pf-v5-c-icon__content pf-m-md"
           >
             <svg
               aria-hidden="true"
@@ -187,10 +187,10 @@ exports[`TagCount component should render a tag count of 11 1`] = `
       type="button"
     >
       <span
-        class="pf-v5-c-icon pf-m-md"
+        class="pf-v5-c-icon"
       >
         <span
-          class="pf-v5-c-icon__content"
+          class="pf-v5-c-icon__content pf-m-md"
         >
           <svg
             aria-hidden="true"


### PR DESCRIPTION
Part of [RHCLOUD-28988](https://issues.redhat.com/browse/RHCLOUD-28988)

- Added `iconSize` param to TagCount for compatibility with FEC
- Fixed `SkeletonTable` export
- Allowed passing className to `ErrorStack` for compatibility with FEC
- Removed extra imports
- Update primaryAction description for `NotAuthorized`