### PR TITLE
Fix CloseButton docs link to source code

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/CloseButton/CloseButton.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/CloseButton/CloseButton.md
@@ -11,6 +11,7 @@ source: react
 # If you use typescript, the name of the interface to display props for
 # These are found through the sourceProps function provided in patternfly-docs.source.js
 propComponents: ['CloseButton']
+sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/CloseButton/CloseButton.md
 ---
 
 import { CloseIcon } from '@patternfly/react-icons';


### PR DESCRIPTION
Previously the docs source code link would try to link to patternfly-react which caused a broken link.