### PR TITLE
fix(WarningModal): Fix WarningModal button variant examples

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalCheckboxExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalCheckboxExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import WarningModal from '@patternfly/react-component-groups/dist/dynamic/WarningModal';
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 export const BasicExample: React.FunctionComponent = () => {
   const [ isOpen, setIsOpen ] = React.useState(false);
@@ -13,7 +13,7 @@ export const BasicExample: React.FunctionComponent = () => {
       onConfirm={() => setIsOpen(false)}
       withCheckbox
       checkboxLabel='Are you sure?'
-      confirmButtonVariant
+      confirmButtonVariant={ButtonVariant.danger}
     >
       Your page contains unsaved changes. Do you want to leave?
     </WarningModal>

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalDangerExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalDangerExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import WarningModal from '@patternfly/react-component-groups/dist/dynamic/WarningModal';
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 export const BasicExample: React.FunctionComponent = () => {
   const [ isOpen, setIsOpen ] = React.useState(false);
@@ -9,7 +9,7 @@ export const BasicExample: React.FunctionComponent = () => {
     <WarningModal
       isOpen={isOpen}
       title='Unsaved changes'
-      confirmButtonVariant
+      confirmButtonVariant={ButtonVariant.danger}
       onClose={() => setIsOpen(false)}
       onConfirm={() => setIsOpen(false)}>
       Your page contains unsaved changes. Do you want to leave?


### PR DESCRIPTION
Fixed WarningModal button variant examples to show danger button variant correctly

<img width="1111" alt="image" src="https://github.com/patternfly/react-component-groups/assets/50696716/7af6c72b-57fb-4977-8bbd-c9bd18b69c59">
