### PR TITLE
feat(mcc): Allow dividers for single content cards

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCard.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCard.md
@@ -48,8 +48,16 @@ Left border can be displayed using `leftBorderVariant`. To display a border unde
 
 ### Expandable multi content card with dividers
 
-Dividers between cards in the content can be shown using `withDividers` flag. 
+Dividers between all cards in the content can be shown using `withDividers` flag. 
 
 ```js file="./MultiContentCardExpandableDividerExample.tsx"
+
+```
+
+### Expandable multi content card with single dividers
+
+To enable a divider just for a single card, use `dividerVariant` property passed to the `cards` array. 
+
+```js file="./MultiContentCardExpandableSingleDividerExample.tsx"
 
 ```

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCard.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCard.md
@@ -7,7 +7,7 @@ propComponents: ['MultiContentCard']
 sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCard.md
 ---
 
-import MultiContentCard from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
+import MultiContentCard, { MultiContentCardDividerVariant, MultiContentCardBorderVariant } from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
 import { ArrowRightIcon, BellIcon, CogIcon, EllipsisVIcon, LockIcon } from '@patternfly/react-icons';
 
 A **multi content card** component allows to display multiple card components in a single layout. To further customize this layout, you can also utilize all properties of the [card component](/components/card), with the exception of `children` and `title`.

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableBorderExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableBorderExample.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MultiContentCard from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
+import MultiContentCard, { MultiContentCardBorderVariant } from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
 import { Button, Card, CardHeader, CardBody, CardFooter, Text, TextContent, TextVariants, Icon, TextList, TextListItem } from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, LockIcon } from '@patternfly/react-icons';
 const cards = [
@@ -96,5 +96,5 @@ const cards = [
 ];
 
 export const BasicExample: React.FunctionComponent = () => (
-  <MultiContentCard isExpandable withHeaderBorder toggleText='Card with border toggle text' leftBorderVariant="primary" cards={cards} />
+  <MultiContentCard isExpandable withHeaderBorder toggleText='Card with border toggle text' leftBorderVariant={MultiContentCardBorderVariant.primary} cards={cards} />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableSingleDividerExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableSingleDividerExample.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import MultiContentCard, { MultiContentCardDividerVariant } from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
+import { Button, Card, CardHeader, CardBody, CardFooter, Text, TextContent, TextVariants, Icon, TextList, TextListItem } from '@patternfly/react-core';
+import { ArrowRightIcon, BellIcon, CogIcon, LockIcon } from '@patternfly/react-icons';
+
+const cards = [
+  <Card isFullHeight isPlain key="card-1">
+    <CardHeader>
+      <TextContent>
+        <Text component={TextVariants.h4}>Getting Started</Text>
+      </TextContent>
+    </CardHeader>
+    <CardBody>
+      <TextContent>
+        <Text className="pf-v5-u-font-size-sm pf-v5-u-font-weight-bold pf-v5-u-mb-sm pf-v5-u-link-color-hover">
+          <Icon size="md" className="pf-v5-u-pl-sm pf-v5-u-pr-md">
+            <CogIcon />
+          </Icon>
+          Configure application
+        </Text>
+        <Text className="pf-v5-u-font-size-sm">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </Text>
+      </TextContent>
+    </CardBody>
+    <CardFooter>
+      <TextContent>
+        <TextList className="pf-v5-u-font-size-sm pf-v5-u-link-color pf-v5-u-ml-0">
+          <TextListItem>
+            <Button variant="link" isInline>First link</Button>
+          </TextListItem>
+          <TextListItem>
+            <Button variant="link" isInline>Second link</Button>
+          </TextListItem>
+          <TextListItem>
+            <Button variant="link" isInline>Another link</Button>
+          </TextListItem>
+        </TextList>
+      </TextContent>
+    </CardFooter>
+  </Card>,
+  <Card isFullHeight isPlain key="card-2">
+    <CardBody className="pf-v5-u-pt-3xl-on-md">
+      <TextContent>
+        <Text className="pf-v5-u-font-size-sm pf-v5-u-font-weight-bold pf-v5-u-mb-sm pf-v5-u-link-color-hover">
+          <Icon size="md" className="pf-v5-u-pl-sm pf-v5-u-pr-md">
+            <LockIcon />
+          </Icon>
+          Configure access
+        </Text>
+        <Text className="pf-v5-u-font-size-sm">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Text>
+      </TextContent>
+    </CardBody>
+    <CardFooter>
+      <Text>
+        <Button variant="link" isInline>
+            Learn more  
+          <Icon className="pf-u-ml-sm" isInline>
+            <ArrowRightIcon />
+          </Icon>
+        </Button>
+      </Text>
+    </CardFooter>
+  </Card>,
+  {
+    content: (
+      <Card isFullHeight isPlain key="card-3">
+        <CardHeader>
+          <TextContent>
+            <Text component={TextVariants.h4}>Next Steps</Text>
+          </TextContent>
+        </CardHeader>
+        <CardBody>
+          <TextContent>
+            <Text className="pf-v5-u-font-size-sm pf-v5-u-font-weight-bold pf-v5-u-mb-sm pf-v5-u-link-color-hover">
+              <Icon size="md" className="pf-v5-u-pl-sm pf-v5-u-pr-md">
+                <BellIcon />
+              </Icon>
+              Configure notifications
+            </Text>
+            <Text className="pf-v5-u-font-size-sm">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </Text>
+          </TextContent>
+        </CardBody>
+        <CardFooter>
+          <Text>
+            <Button variant="link" isInline>
+              Learn more  
+              <Icon className="pf-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            </Button>
+          </Text>
+        </CardFooter>
+      </Card>
+    ), 
+    dividerVariant: 'left' as MultiContentCardDividerVariant
+  }
+];
+
+export const BasicExample: React.FunctionComponent = () => <MultiContentCard isExpandable toggleText='Card with dividers toggle text' cards={cards} />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableSingleDividerExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableSingleDividerExample.tsx
@@ -97,7 +97,7 @@ const cards = [
         </CardFooter>
       </Card>
     ), 
-    dividerVariant: 'left' as MultiContentCardDividerVariant
+    dividerVariant: MultiContentCardDividerVariant.left
   }
 ];
 

--- a/packages/module/src/MultiContentCard/MultiContentCard.test.tsx
+++ b/packages/module/src/MultiContentCard/MultiContentCard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen, render } from '@testing-library/react';
 import { Button, Card, CardHeader, CardBody, Text, TextContent, TextVariants, Icon, TextList, TextListItem, CardFooter, Dropdown, MenuToggle, DropdownList, DropdownItem, MenuToggleElement } from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, EllipsisVIcon, LockIcon } from '@patternfly/react-icons';
-import MultiContentCard from './MultiContentCard';
+import MultiContentCard, { MultiContentCardDividerVariant } from './MultiContentCard';
 
 const cards = [
   <Card isFullHeight isPlain key="card-1">
@@ -192,7 +192,7 @@ describe('MultiContentCard component', () => {
   });
 
   it('should render multi content card with a single divider', () => {
-    const { container } = render(<MultiContentCard cards={[ cards[0], cards[1], { content: cards[2], dividerVariant: 'left' } ]} />);
+    const { container } = render(<MultiContentCard cards={[ cards[0], cards[1], { content: cards[2], dividerVariant: MultiContentCardDividerVariant.left } ]} />);
 
     expect(screen.getAllByRole('separator')).toHaveLength(1);
 

--- a/packages/module/src/MultiContentCard/MultiContentCard.test.tsx
+++ b/packages/module/src/MultiContentCard/MultiContentCard.test.tsx
@@ -191,4 +191,12 @@ describe('MultiContentCard component', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('should render multi content card with a single divider', () => {
+    const { container } = render(<MultiContentCard cards={[ cards[0], cards[1], { content: cards[2], dividerVariant: 'left' } ]} />);
+
+    expect(screen.getAllByRole('separator')).toHaveLength(1);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
 });

--- a/packages/module/src/MultiContentCard/MultiContentCard.tsx
+++ b/packages/module/src/MultiContentCard/MultiContentCard.tsx
@@ -15,9 +15,18 @@ import clsx from 'clsx';
 
 export type MultiContentCardBorderVariant = 'primary' | 'danger' | 'success' | 'info' | 'warning' | 'hidden';
 
+export type MultiContentCardDividerVariant = 'left' | 'right';
+
+export interface MutliContentCardProps {
+  /** Card element to be displayed as a content */
+  content: React.ReactElement;
+  /** Allows adding divider on the left/right from the card */
+  dividerVariant?: MultiContentCardDividerVariant;
+}
+
 export interface MultiContentCardProps extends Omit<CardProps, 'children' | 'title'> {
   /** Cards to be displayed as a content */
-  cards?: React.ReactElement[];
+  cards?: (React.ReactElement | MutliContentCardProps)[];
   /** Actions to be displayed in the expandable section */
   actions?: React.ReactElement;
   /** Toggle text for the expandable section */
@@ -26,7 +35,7 @@ export interface MultiContentCardProps extends Omit<CardProps, 'children' | 'tit
   toggleContent?: React.ReactElement;
   /** Left border variant for the containing card */
   leftBorderVariant?: MultiContentCardBorderVariant;
-  /** Indicates whether the content is separated by dividers */
+  /** When set to true, all content cards will be separated with dividers */
   withDividers?: boolean;
   /** Indicates whether the card is expandable */
   isExpandable?: boolean;
@@ -66,21 +75,29 @@ const MultiContentCard: React.FunctionComponent<MultiContentCardProps> = ({
     setIsExpanded(!isExpanded);
   };
   
-  const renderCards = (cards: React.ReactElement[], withDividers?: boolean) =>  (
+  const renderCards = (cards: (React.ReactElement | MutliContentCardProps)[], withDividers?: boolean) =>  (
     <Flex alignSelf={{ default: 'alignSelfStretch' }} alignItems={{ default: 'alignItemsStretch' }}>
-      {cards.map((card, index) => (
-        <>
-          <FlexItem key={`card-${index}`} flex={{ default: 'flex_1' }}>
-            {card}
-          </FlexItem>
-          {(index + 1 < cards.length && withDividers) && (
-            <Divider 
-              orientation={{ md: 'vertical' }} 
-              inset={{ default: 'inset3xl' }}
-            />
-          )}
-        </>
-      ))} 
+      {cards.map((card, index) => {
+        const isElement = React.isValidElement(card);
+        return (
+          <>
+            {(index > 0 && !isElement && ((card as MutliContentCardProps).dividerVariant === 'left')) && (
+              <Divider 
+                orientation={{ md: 'vertical' }} 
+                inset={{ default: 'inset3xl' }}
+              />
+            )}
+            <FlexItem key={`card-${index}`} flex={{ default: 'flex_1' }}>
+              {isElement ? card as React.ReactNode : (card as MutliContentCardProps).content}
+            </FlexItem>
+            {(index + 1 < cards.length && (withDividers || !isElement && (card as MutliContentCardProps).dividerVariant === 'right')) && (
+              <Divider 
+                orientation={{ md: 'vertical' }} 
+                inset={{ default: 'inset3xl' }}
+              />
+            )}
+          </>
+        )})} 
     </Flex>
   );
   

--- a/packages/module/src/MultiContentCard/MultiContentCard.tsx
+++ b/packages/module/src/MultiContentCard/MultiContentCard.tsx
@@ -13,9 +13,23 @@ import {
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
 
-export type MultiContentCardBorderVariant = 'primary' | 'danger' | 'success' | 'info' | 'warning' | 'hidden';
+export const MultiContentCardBorderVariant = {
+  primary: 'primary',
+  danger: 'danger',
+  success: 'success',
+  info: 'info',
+  warning: 'warning',
+  hidden: 'hidden'
+} as const;
 
-export type MultiContentCardDividerVariant = 'left' | 'right';
+export type MultiContentCardBorderVariant = typeof MultiContentCardBorderVariant[keyof typeof MultiContentCardBorderVariant];
+
+export const MultiContentCardDividerVariant = {
+  left: 'left',
+  right: 'right'
+} as const;
+
+export type MultiContentCardDividerVariant = typeof MultiContentCardDividerVariant[keyof typeof MultiContentCardDividerVariant];
 
 export interface MutliContentCardProps {
   /** Card element to be displayed as a content */
@@ -56,6 +70,10 @@ const useStyles = createUseStyles({
   })
 })
 
+export const isCardWithProps = (
+  card: React.ReactElement | MutliContentCardProps
+): card is MutliContentCardProps => !!card && !React.isValidElement(card);
+
 const MultiContentCard: React.FunctionComponent<MultiContentCardProps> = ({
   cards = [],
   isToggleRightAligned = false,
@@ -63,7 +81,7 @@ const MultiContentCard: React.FunctionComponent<MultiContentCardProps> = ({
   toggleText,
   toggleContent,
   withDividers = false,
-  leftBorderVariant = 'hidden',
+  leftBorderVariant = MultiContentCardBorderVariant.hidden,
   isExpandable = false,
   defaultExpanded = true,
   withHeaderBorder = false,
@@ -77,32 +95,30 @@ const MultiContentCard: React.FunctionComponent<MultiContentCardProps> = ({
   
   const renderCards = (cards: (React.ReactElement | MutliContentCardProps)[], withDividers?: boolean) =>  (
     <Flex alignSelf={{ default: 'alignSelfStretch' }} alignItems={{ default: 'alignItemsStretch' }}>
-      {cards.map((card, index) => {
-        const isElement = React.isValidElement(card);
-        return (
-          <>
-            {(index > 0 && !isElement && ((card as MutliContentCardProps).dividerVariant === 'left')) && (
-              <Divider 
-                orientation={{ md: 'vertical' }} 
-                inset={{ default: 'inset3xl' }}
-              />
-            )}
-            <FlexItem key={`card-${index}`} flex={{ default: 'flex_1' }}>
-              {isElement ? card as React.ReactNode : (card as MutliContentCardProps).content}
-            </FlexItem>
-            {(index + 1 < cards.length && (withDividers || !isElement && (card as MutliContentCardProps).dividerVariant === 'right')) && (
-              <Divider 
-                orientation={{ md: 'vertical' }} 
-                inset={{ default: 'inset3xl' }}
-              />
-            )}
-          </>
-        )})} 
+      {cards.map((card, index) => (
+        <>
+          {index > 0 && isCardWithProps(card) && card.dividerVariant === MultiContentCardDividerVariant.left && (
+            <Divider 
+              orientation={{ md: 'vertical' }} 
+              inset={{ default: 'inset3xl' }}
+            />
+          )}
+          <FlexItem key={`card-${index}`} flex={{ default: 'flex_1' }}>
+            {isCardWithProps(card) ? card.content : card}
+          </FlexItem>
+          {(index + 1 < cards.length && (withDividers || isCardWithProps(card) && card.dividerVariant === MultiContentCardDividerVariant.right)) && (
+            <Divider 
+              orientation={{ md: 'vertical' }} 
+              inset={{ default: 'inset3xl' }}
+            />
+          )}
+        </>
+      ))} 
     </Flex>
   );
   
   return(
-    <Card className={clsx([ { [classes.multiContentCardLeftBorder]: leftBorderVariant !== 'hidden' } ])} isExpanded={isExpanded} {...rest}>
+    <Card className={clsx([ { [classes.multiContentCardLeftBorder]: leftBorderVariant !== MultiContentCardBorderVariant.hidden } ])} isExpanded={isExpanded} {...rest}>
       {isExpandable && (
         <CardHeader
           className={clsx({ [classes.multiContentCardHeadingBorder]: withHeaderBorder })}

--- a/packages/module/src/MultiContentCard/__snapshots__/MultiContentCard.test.tsx.snap
+++ b/packages/module/src/MultiContentCard/__snapshots__/MultiContentCard.test.tsx.snap
@@ -1013,6 +1013,383 @@ exports[`MultiContentCard component should render expandable multi content card 
 </div>
 `;
 
+exports[`MultiContentCard component should render multi content card with a single divider 1`] = `
+<div
+  class="pf-v5-c-card pf-m-expanded"
+  data-ouia-component-id="OUIA-Generated-Card-15"
+  data-ouia-component-type="PF5/Card"
+  data-ouia-safe="true"
+  id=""
+>
+  <div
+    class="pf-v5-l-flex pf-m-align-items-stretch pf-m-align-self-stretch"
+  >
+    <div
+      class="pf-m-flex-1"
+    >
+      <div
+        class="pf-v5-c-card pf-m-full-height pf-m-plain"
+        data-ouia-component-id="OUIA-Generated-Card-16"
+        data-ouia-component-type="PF5/Card"
+        data-ouia-safe="true"
+        id=""
+      >
+        <div
+          class="pf-v5-c-card__header"
+        >
+          <div
+            class="pf-v5-c-card__header-main"
+          >
+            <div
+              class="pf-v5-c-content"
+            >
+              <h4
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-31"
+                data-ouia-component-type="PF5/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                Getting Started
+              </h4>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-card__body"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <p
+              class="pf-v5-u-font-size-sm pf-v5-u-font-weight-bold pf-v5-u-mb-sm pf-v5-u-link-color-hover"
+              data-ouia-component-id="OUIA-Generated-Text-32"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <span
+                class="pf-v5-c-icon pf-m-md pf-v5-u-pl-sm pf-v5-u-pr-md"
+              >
+                <span
+                  class="pf-v5-c-icon__content"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              Configure application
+            </p>
+            <p
+              class="pf-v5-u-font-size-sm"
+              data-ouia-component-id="OUIA-Generated-Text-33"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-card__footer"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <ul
+              class="pf-v5-u-font-size-sm pf-v5-u-link-color pf-v5-u-ml-0"
+            >
+              <li
+                class=""
+              >
+                <button
+                  aria-disabled="false"
+                  class="pf-v5-c-button pf-m-link pf-m-inline"
+                  data-ouia-component-id="OUIA-Generated-Button-link-16"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  First link
+                </button>
+              </li>
+              <li
+                class=""
+              >
+                <button
+                  aria-disabled="false"
+                  class="pf-v5-c-button pf-m-link pf-m-inline"
+                  data-ouia-component-id="OUIA-Generated-Button-link-17"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  Second link
+                </button>
+              </li>
+              <li
+                class=""
+              >
+                <button
+                  aria-disabled="false"
+                  class="pf-v5-c-button pf-m-link pf-m-inline"
+                  data-ouia-component-id="OUIA-Generated-Button-link-18"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  Another link
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-flex-1"
+    >
+      <div
+        class="pf-v5-c-card pf-m-full-height pf-m-plain"
+        data-ouia-component-id="OUIA-Generated-Card-17"
+        data-ouia-component-type="PF5/Card"
+        data-ouia-safe="true"
+        id=""
+      >
+        <div
+          class="pf-v5-c-card__body pf-v5-u-pt-3xl-on-md"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <p
+              class="pf-v5-u-font-size-sm pf-v5-u-font-weight-bold pf-v5-u-mb-sm pf-v5-u-link-color-hover"
+              data-ouia-component-id="OUIA-Generated-Text-34"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <span
+                class="pf-v5-c-icon pf-m-md pf-v5-u-pl-sm pf-v5-u-pr-md"
+              >
+                <span
+                  class="pf-v5-c-icon__content"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              Configure access
+            </p>
+            <p
+              class="pf-v5-u-font-size-sm"
+              data-ouia-component-id="OUIA-Generated-Text-35"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            </p>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-card__footer"
+        >
+          <p
+            class=""
+            data-ouia-component-id="OUIA-Generated-Text-36"
+            data-ouia-component-type="PF5/Text"
+            data-ouia-safe="true"
+            data-pf-content="true"
+          >
+            <button
+              aria-disabled="false"
+              class="pf-v5-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-19"
+              data-ouia-component-type="PF5/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              Learn more
+              <span
+                class="pf-v5-c-icon pf-m-inline pf-u-ml-sm"
+              >
+                <span
+                  class="pf-v5-c-icon__content"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+          </p>
+        </div>
+      </div>
+    </div>
+    <hr
+      class="pf-v5-c-divider pf-m-inset-3xl pf-m-vertical-on-md"
+    />
+    <div
+      class="pf-m-flex-1"
+    >
+      <div
+        class="pf-v5-c-card pf-m-full-height pf-m-plain"
+        data-ouia-component-id="OUIA-Generated-Card-18"
+        data-ouia-component-type="PF5/Card"
+        data-ouia-safe="true"
+        id=""
+      >
+        <div
+          class="pf-v5-c-card__header"
+        >
+          <div
+            class="pf-v5-c-card__header-main"
+          >
+            <div
+              class="pf-v5-c-content"
+            >
+              <h4
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-37"
+                data-ouia-component-type="PF5/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                Next Steps
+              </h4>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-card__body"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <p
+              class="pf-v5-u-font-size-sm pf-v5-u-font-weight-bold pf-v5-u-mb-sm pf-v5-u-link-color-hover"
+              data-ouia-component-id="OUIA-Generated-Text-38"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <span
+                class="pf-v5-c-icon pf-m-md pf-v5-u-pl-sm pf-v5-u-pr-md"
+              >
+                <span
+                  class="pf-v5-c-icon__content"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 896 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M448,0 C465.333333,0 480.333333,6.33333333 493,19 C505.666667,31.6666667 512,46.6666667 512,64 L512,106 L514.23,106.45 C587.89,121.39 648.48,157.24 696,214 C744,271.333333 768,338.666667 768,416 C768,500 780,568.666667 804,622 C818.666667,652.666667 841.333333,684 872,716 C873.773676,718.829136 875.780658,721.505113 878,724 C890,737.333333 896,752.333333 896,769 C896,785.666667 890,800.333333 878,813 C866,825.666667 850.666667,832 832,832 L63.3,832 C44.9533333,831.84 29.8533333,825.506667 18,813 C6,800.333333 0,785.666667 0,769 C0,752.333333 6,737.333333 18,724 L24,716 L25.06,714.9 C55.1933333,683.28 77.5066667,652.313333 92,622 C116,568.666667 128,500 128,416 C128,338.666667 152,271.333333 200,214 C248,156.666667 309.333333,120.666667 384,106 L384,63.31 C384.166667,46.27 390.5,31.5 403,19 C415.666667,6.33333333 430.666667,0 448,0 Z M576,896 L576,897.08 C575.74,932.6 563.073333,962.573333 538,987 C512.666667,1011.66667 482.666667,1024 448,1024 C413.333333,1024 383.333333,1011.66667 358,987 C332.666667,962.333333 320,932 320,896 L576,896 Z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              Configure notifications
+            </p>
+            <p
+              class="pf-v5-u-font-size-sm"
+              data-ouia-component-id="OUIA-Generated-Text-39"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-card__footer"
+        >
+          <p
+            class=""
+            data-ouia-component-id="OUIA-Generated-Text-40"
+            data-ouia-component-type="PF5/Text"
+            data-ouia-safe="true"
+            data-pf-content="true"
+          >
+            <button
+              aria-disabled="false"
+              class="pf-v5-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-20"
+              data-ouia-component-type="PF5/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              Learn more
+              <span
+                class="pf-v5-c-icon pf-m-inline pf-u-ml-sm"
+              >
+                <span
+                  class="pf-v5-c-icon__content"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`MultiContentCard component should render multi content card with dividers 1`] = `
 <div
   class="pf-v5-c-card pf-m-expanded"


### PR DESCRIPTION
[RHCLOUD-31339](https://issues.redhat.com/browse/RHCLOUD-31339)

Allowed dividers for single content cards 

![image](https://github.com/patternfly/react-component-groups/assets/50696716/09dbba2c-b849-4507-9326-55d44dbc9aba)

closes #120 