### PR TITLE
fix(docs): Update about component groups source link

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/component-groups/about-component-groups.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/about-component-groups.md
@@ -3,6 +3,7 @@ section: extensions
 subsection: Component groups
 id: About component groups
 sortValue: 1
+sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/about-component-groups.md
 --- 
 
 Component groups lives in its own package [`@patternfly/react-component-groups`](https://www.npmjs.com/package/@patternfly/react-component-groups) 


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-org/issues/3891

The "View source on Github" link was broken on the ["About Component Groups" Page](https://www.patternfly.org/extensions/component-groups/about-component-groups) so I added the sourceLink to the docs 