### PR TITLE
fix(WarningModal): Reset check state on close

### DIFF
--- a/packages/module/src/WarningModal/WarningModal.tsx
+++ b/packages/module/src/WarningModal/WarningModal.tsx
@@ -44,7 +44,10 @@ const WarningModal: React.FunctionComponent<WarningModalProps> = ({
           ouiaId="primary-confirm-button"
           key="confirm"
           variant={confirmButtonVariant}
-          onClick={onConfirm}
+          onClick={() => {
+            onConfirm?.();
+            setChecked(false);
+          }}
           isDisabled={withCheckbox && !checked}
         >
           {confirmButtonLabel}
@@ -64,7 +67,7 @@ const WarningModal: React.FunctionComponent<WarningModalProps> = ({
       {withCheckbox ? (
         <Checkbox
           isChecked={checked}
-          onChange={() => setChecked(!checked)}
+          onChange={(_event, value) => setChecked(value)}
           label={checkboxLabel}
           id="warning-modal-check"
           className="pf-v5-u-mt-lg"


### PR DESCRIPTION
[RHCLOUD-31959](https://issues.redhat.com/browse/RHCLOUD-31959)

The check state of the confirmation checkbox now correctly resets on closing the modal

