### PR TITLE
feat: Add new Column Management Modal component

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
@@ -15,6 +15,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import ColumnManagementModal from '@patternfly/react-component-groups/dist/dynamic/ColumnManagementModal';
+import { ColumnsIcon } from '@patternfly/react-icons';
 
 The **column management modal** component can be used to implement customizable table columns. Columns can be configured to be enabled or disabled by default or be unhidable.
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
@@ -22,7 +22,7 @@ The **column management modal** component can be used to implement customizable 
 
 ### Showing and hiding of table columns
 
-Clicking the "Manage columns" button will open the column management modal. The "ID" column is set to unhideable with `isAlwaysShown: true`, therefore its checkbox is disabled. "Score" column is set to be hidden by default. Always make sure to set `isShownByDefault` and `isShown` to the same boolean value in the initial state.
+Clicking the "Manage columns" button will open the column management modal. The "ID" column should not be toggleable, therefore its checkbox is disabled with `isUntoggleable: true`. "Score" column is set to be hidden by default. Always make sure to set `isShownByDefault` and `isShown` to the same boolean value in the initial state.
 
 
 ```js file="./ColumnManagementModalExample.tsx"

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
@@ -1,0 +1,30 @@
+---
+# Sidenav top-level section
+# should be the same for all markdown files
+section: extensions
+subsection: Component groups
+# Sidenav secondary level section
+# should be the same for all markdown files
+id: Column management modal
+# Tab (react | react-demos | html | html-demos | design-guidelines | accessibility)
+source: react
+# If you use typescript, the name of the interface to display props for
+# These are found through the sourceProps function provided in patternfly-docs.source.js
+propComponents: ['ColumnManagementModal']
+sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
+---
+
+import ColumnManagementModal from '@patternfly/react-component-groups/dist/dynamic/ColumnManagementModal';
+
+The **column management modal** component can be used to implement customizable table columns. Columns can be configured to be enabled or disabled by default or be unhidable.
+
+## Examples
+
+### Showing and hiding of table columns
+
+Clicking the "Manage columns" button will open the column management modal. The "CVE ID" column is set to unhideable with `isAlwaysShown: true`, therefore its checkbox is disabled. "CVSS base score" column is set to be hidden by default. Always make sure to set `isShownByDefault` and `isShown` to the same boolean value in the initial state.
+
+
+```js file="./ColumnManagementModalExample.tsx"
+
+```

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
@@ -22,8 +22,7 @@ The **column management modal** component can be used to implement customizable 
 
 ### Showing and hiding of table columns
 
-Clicking the "Manage columns" button will open the column management modal. The "ID" column should not be toggleable, therefore its checkbox is disabled with `isUntoggleable: true`. "Score" column is set to be hidden by default. Always make sure to set `isShownByDefault` and `isShown` to the same boolean value in the initial state.
-For further customization, you can utilize all properties of the [modal component](/components/modal), with the exception of `ref`.
+Clicking the "Manage columns" button will open the column management modal. The "ID" column should not be toggleable, therefore its checkbox is disabled with `isUntoggleable: true`. The "Score" column is set to be hidden by default. Always make sure to set `isShownByDefault` and `isShown` to the same boolean value in the initial state. For further customization, you can utilize all properties of the [modal component](/components/modal), except `ref` and `children`.
 
 ```js file="./ColumnManagementModalExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
@@ -22,7 +22,7 @@ The **column management modal** component can be used to implement customizable 
 
 ### Showing and hiding of table columns
 
-Clicking the "Manage columns" button will open the column management modal. The "CVE ID" column is set to unhideable with `isAlwaysShown: true`, therefore its checkbox is disabled. "CVSS base score" column is set to be hidden by default. Always make sure to set `isShownByDefault` and `isShown` to the same boolean value in the initial state.
+Clicking the "Manage columns" button will open the column management modal. The "ID" column is set to unhideable with `isAlwaysShown: true`, therefore its checkbox is disabled. "Score" column is set to be hidden by default. Always make sure to set `isShownByDefault` and `isShown` to the same boolean value in the initial state.
 
 
 ```js file="./ColumnManagementModalExample.tsx"

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
@@ -23,7 +23,7 @@ The **column management modal** component can be used to implement customizable 
 ### Showing and hiding of table columns
 
 Clicking the "Manage columns" button will open the column management modal. The "ID" column should not be toggleable, therefore its checkbox is disabled with `isUntoggleable: true`. "Score" column is set to be hidden by default. Always make sure to set `isShownByDefault` and `isShown` to the same boolean value in the initial state.
-
+For further customization, you can utilize all properties of the [modal component](/components/modal), with the exception of `ref`.
 
 ```js file="./ColumnManagementModalExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
@@ -60,17 +60,17 @@ const ROWS = [
 
 export const ColumnManagementModalExample: React.FunctionComponent = () => {
   const [ columns, setColumns ] = React.useState(DEFAULT_COLUMNS);
-  const [ isModalOpen, setModalOpen ] = React.useState(false);
+  const [ isOpen, setOpen ] = React.useState(false);
   
   return (
     <>
       <ColumnManagementModal
         appliedColumns={columns}
         applyColumns={newColumns => setColumns(newColumns)}
-        isModalOpen={isModalOpen}
-        setModalOpen={setModalOpen}
+        isOpen={isOpen}
+        onClose={() => setOpen(false)}
       />
-      <Button onClick={() => setModalOpen(true)}>Manage columns</Button>
+      <Button onClick={() => setOpen(true)}>Manage columns</Button>
       <Table
         aria-label="Simple table"
         variant="compact"

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
@@ -5,15 +5,15 @@ import ColumnManagementModal, { ColumnManagementModalColumn } from '@patternfly/
 
 const DEFAULT_COLUMNS: ColumnManagementModalColumn[] = [
   {
-    title: 'CVE ID',
-    key: 'synopsis',
+    title: 'ID',
+    key: 'id',
     isShownByDefault: true,
     isShown: true,
     isAlwaysShown: true
   },
   {
     title: 'Publish date',
-    key: 'publish_date',
+    key: 'publishDate',
     isShownByDefault: true,
     isShown: true
   },
@@ -24,41 +24,39 @@ const DEFAULT_COLUMNS: ColumnManagementModalColumn[] = [
     isShown: true
   },
   {
-    title: 'CVSS base score',
-    key: 'cvss_score',
+    title: 'Score',
+    key: 'score',
     isShownByDefault: false,
     isShown: false
   }
 ];
 
-/* eslint-disable camelcase */
 const ROWS = [
   {
-    synopsis: 'CVE-2024-1546',
-    publish_date: '20 Feb 2024',
+    id: 'CVE-2024-1546',
+    publishDate: '20 Feb 2024',
     impact: 'Important',
-    cvss_score: '7.5'
+    score: '7.5'
   },
   {
-    synopsis: 'CVE-2024-1547',
-    publish_date: '20 Feb 2024',
+    id: 'CVE-2024-1547',
+    publishDate: '20 Feb 2024',
     impact: 'Important',
-    cvss_score: '7.5'
+    score: '7.5'
   },
   {
-    synopsis: 'CVE-2024-1548',
-    publish_date: '20 Feb 2024',
+    id: 'CVE-2024-1548',
+    publishDate: '20 Feb 2024',
     impact: 'Moderate',
-    cvss_score: '6.1'
+    score: '6.1'
   },
   {
-    synopsis: 'CVE-2024-1549',
-    publish_date: '20 Feb 2024',
+    id: 'CVE-2024-1549',
+    publishDate: '20 Feb 2024',
     impact: 'Moderate',
-    cvss_score: '6.1'
+    score: '6.1'
   }
 ]
-/* eslint-enable camelcase */
 
 export const ColumnManagementModalExample: React.FunctionComponent = () => {
   const [ columns, setColumns ] = React.useState(DEFAULT_COLUMNS);
@@ -71,7 +69,6 @@ export const ColumnManagementModalExample: React.FunctionComponent = () => {
         applyColumns={newColumns => setColumns(newColumns)}
         isModalOpen={isModalOpen}
         setModalOpen={setModalOpen}
-        key="column-mgmt-modal"
       />
       <Button onClick={() => setModalOpen(true)}>Manage columns</Button>
       <Table

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Tr, Thead } from '@patternfly/react-table';
+import { ColumnsIcon } from '@patternfly/react-icons';
 import ColumnManagementModal, { ColumnManagementModalColumn } from '@patternfly/react-component-groups/dist/dynamic/ColumnManagementModal';
 
 const DEFAULT_COLUMNS: ColumnManagementModalColumn[] = [
@@ -70,7 +71,7 @@ export const ColumnManagementModalExample: React.FunctionComponent = () => {
         isOpen={isOpen}
         onClose={() => setOpen(false)}
       />
-      <Button onClick={() => setOpen(true)}>Manage columns</Button>
+      <Button onClick={() => setOpen(true)} variant={ButtonVariant.secondary} icon={<ColumnsIcon />}>Manage columns</Button>
       <Table
         aria-label="Simple table"
         variant="compact"

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
@@ -9,7 +9,7 @@ const DEFAULT_COLUMNS: ColumnManagementModalColumn[] = [
     key: 'id',
     isShownByDefault: true,
     isShown: true,
-    isAlwaysShown: true
+    isUntoggleable: true
   },
   {
     title: 'Publish date',

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { Button } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Tr, Thead } from '@patternfly/react-table';
+import ColumnManagementModal, { ColumnManagementModalColumn } from '@patternfly/react-component-groups/dist/dynamic/ColumnManagementModal';
+
+const DEFAULT_COLUMNS: ColumnManagementModalColumn[] = [
+  {
+    title: 'CVE ID',
+    key: 'synopsis',
+    isShownByDefault: true,
+    isShown: true,
+    isAlwaysShown: true
+  },
+  {
+    title: 'Publish date',
+    key: 'publish_date',
+    isShownByDefault: true,
+    isShown: true
+  },
+  {
+    title: 'Impact',
+    key: 'impact',
+    isShownByDefault: true,
+    isShown: true
+  },
+  {
+    title: 'CVSS base score',
+    key: 'cvss_score',
+    isShownByDefault: false,
+    isShown: false
+  }
+];
+
+/* eslint-disable camelcase */
+const ROWS = [
+  {
+    synopsis: 'CVE-2024-1546',
+    publish_date: '20 Feb 2024',
+    impact: 'Important',
+    cvss_score: '7.5'
+  },
+  {
+    synopsis: 'CVE-2024-1547',
+    publish_date: '20 Feb 2024',
+    impact: 'Important',
+    cvss_score: '7.5'
+  },
+  {
+    synopsis: 'CVE-2024-1548',
+    publish_date: '20 Feb 2024',
+    impact: 'Moderate',
+    cvss_score: '6.1'
+  },
+  {
+    synopsis: 'CVE-2024-1549',
+    publish_date: '20 Feb 2024',
+    impact: 'Moderate',
+    cvss_score: '6.1'
+  }
+]
+/* eslint-enable camelcase */
+
+export const ColumnManagementModalExample: React.FunctionComponent = () => {
+  const [ columns, setColumns ] = React.useState(DEFAULT_COLUMNS);
+  const [ isModalOpen, setModalOpen ] = React.useState(false);
+  
+  return (
+    <>
+      <ColumnManagementModal
+        appliedColumns={columns}
+        applyColumns={newColumns => setColumns(newColumns)}
+        isModalOpen={isModalOpen}
+        setModalOpen={setModalOpen}
+        key="column-mgmt-modal"
+      />
+      <Button onClick={() => setModalOpen(true)}>Manage columns</Button>
+      <Table
+        aria-label="Simple table"
+        variant="compact"
+      >
+        <Thead>
+          <Tr>
+            {columns.filter(column => column.isShown).map(column => <Th key={column.key}>{column.title}</Th>)}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {ROWS.map((row, rowIndex) => 
+            <Tr key={rowIndex}>
+              {columns.filter(column => column.isShown).map((column, columnIndex) =>
+                <Td key={columnIndex}>{row[column.key]}</Td>
+              )}
+            </Tr>  
+          )}
+        </Tbody>
+      </Table>
+    </>
+  )
+}

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
@@ -31,15 +31,15 @@ const DEFAULT_COLUMNS : ColumnManagementModalColumn[] = [
   }
 ];
 
-const setModalOpen = jest.fn();
+const onClose = jest.fn();
 const setColumns = jest.fn();
 
 beforeEach(() => {
   render(<ColumnManagementModal
     appliedColumns={DEFAULT_COLUMNS}
     applyColumns={newColumns => setColumns(newColumns)}
-    isModalOpen
-    setModalOpen={setModalOpen}
+    isOpen
+    onClose={onClose}
     data-testid="column-mgmt-modal"
   />);
 });
@@ -55,7 +55,7 @@ describe('ColumnManagementModal component', () => {
   });
 
   it('should have checkbox checked if column is shown by default', () => {
-    const idCheckbox = screen.getByTestId('column-mgmt-modal').querySelector('input[type="checkbox"][aria-labelledby="id"]');
+    const idCheckbox = screen.getByTestId('column-mgmt-modal').querySelector('input[type="checkbox"][data-ouia-component-id="ColumnManagementModal-column0-checkbox"]');
 
     expect(idCheckbox).toHaveAttribute('disabled');
     expect(idCheckbox).toHaveAttribute('checked');
@@ -95,7 +95,7 @@ describe('ColumnManagementModal component', () => {
 
     impactColumn.isShown = false;
 
-    expect(setModalOpen).toHaveBeenCalledWith(false);
+    expect(onClose).toHaveBeenCalled();
     expect(setColumns).toHaveBeenCalledWith(expectedColumns);
   });
 
@@ -103,7 +103,7 @@ describe('ColumnManagementModal component', () => {
     fireEvent.click(screen.getByText('Impact'));
     fireEvent.click(screen.getByText('Cancel'));
 
-    expect(setModalOpen).toHaveBeenCalledWith(false);
+    expect(onClose).toHaveBeenCalled();
     expect(setColumns).toHaveBeenCalledWith(DEFAULT_COLUMNS);
   });
 });

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react';
+import ColumnManagementModal, { ColumnManagementModalColumn } from './ColumnManagementModal';
+
+const DEFAULT_COLUMNS : ColumnManagementModalColumn[] = [
+  {
+    title: 'CVE ID',
+    key: 'synopsis',
+    isShownByDefault: true,
+    isShown: true,
+    isAlwaysShown: true
+  },
+  {
+    title: 'Publish date',
+    key: 'publish_date',
+    isShownByDefault: true,
+    isShown: true
+  },
+  {
+    title: 'Impact',
+    key: 'impact',
+    isShownByDefault: true,
+    isShown: true
+  },
+  {
+    title: 'CVSS base score',
+    key: 'cvss_score',
+    isShownByDefault: false,
+    isShown: false
+  }
+];
+
+const setModalOpen = jest.fn();
+const setColumns = jest.fn();
+
+beforeEach(() => {
+  render(<ColumnManagementModal
+    appliedColumns={DEFAULT_COLUMNS}
+    applyColumns={newColumns => setColumns(newColumns)}
+    isModalOpen
+    setModalOpen={setModalOpen}
+    key="column-mgmt-modal"
+    data-testid="column-mgmt-modal"
+  />);
+});
+
+const getCheckboxesState = () => {
+  const checkboxes = screen.getByTestId('column-mgmt-modal').querySelectorAll('input[type="checkbox"]');
+  return (Array.from(checkboxes) as HTMLInputElement[]).map(c => c.checked);
+}
+
+describe('ColumnManagementModal component', () => {
+  it('should have disabled and checked checkboxes for columns that should always be shown', () => {
+    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map(c => c.isShownByDefault));
+  });
+
+  it('should have checkbox checked if column is shown by default', () => {
+    const idCheckbox = screen.getByTestId('column-mgmt-modal').querySelector('input[type="checkbox"][aria-labelledby="synopsis"]');
+
+    expect(idCheckbox).toHaveAttribute('disabled');
+    expect(idCheckbox).toHaveAttribute('checked');
+  });
+
+  it('should set columns to default state upon clicking on "Reset to default"', () => {
+    // disable Impact column which is enabled by default
+    fireEvent.click(screen.getByText('Impact'));
+
+    // enable CVSS base score column which is disabled by default
+    fireEvent.click(screen.getByText('CVSS base score'));
+
+    fireEvent.click(screen.getByText('Reset to default'));
+  
+    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map(c => c.isShownByDefault));
+  });
+
+  it('should set all columns to show upon clicking on "Select all"', () => {
+    // disable Impact column which is enabled by default
+    fireEvent.click(screen.getByText('Impact'));
+
+    fireEvent.click(screen.getByText('Select all'));
+
+    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map(_ => true));
+  });
+
+  it('should change columns on save', () => {
+    fireEvent.click(screen.getByText('Impact'));
+    fireEvent.click(screen.getByText('Save'));
+
+    const expectedColumns = DEFAULT_COLUMNS;
+    const impactColumn = expectedColumns.find(c => c.title === 'Impact');
+
+    if (impactColumn === undefined) {
+      throw new Error('Expected to find "Impact" column in "DEFAULT_COLUMNS"');
+    }
+
+    impactColumn.isShown = false;
+
+    expect(setModalOpen).toHaveBeenCalledWith(false);
+    expect(setColumns).toHaveBeenCalledWith(expectedColumns);
+  });
+
+  it('should retain columns on cancel', () => {
+    fireEvent.click(screen.getByText('Impact'));
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(setModalOpen).toHaveBeenCalledWith(false);
+    expect(setColumns).toHaveBeenCalledWith(DEFAULT_COLUMNS);
+  });
+});

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
@@ -5,15 +5,15 @@ import ColumnManagementModal, { ColumnManagementModalColumn } from './ColumnMana
 
 const DEFAULT_COLUMNS : ColumnManagementModalColumn[] = [
   {
-    title: 'CVE ID',
-    key: 'synopsis',
+    title: 'ID',
+    key: 'id',
     isShownByDefault: true,
     isShown: true,
     isAlwaysShown: true
   },
   {
     title: 'Publish date',
-    key: 'publish_date',
+    key: 'publishDate',
     isShownByDefault: true,
     isShown: true
   },
@@ -24,8 +24,8 @@ const DEFAULT_COLUMNS : ColumnManagementModalColumn[] = [
     isShown: true
   },
   {
-    title: 'CVSS base score',
-    key: 'cvss_score',
+    title: 'Score',
+    key: 'score',
     isShownByDefault: false,
     isShown: false
   }
@@ -40,7 +40,6 @@ beforeEach(() => {
     applyColumns={newColumns => setColumns(newColumns)}
     isModalOpen
     setModalOpen={setModalOpen}
-    key="column-mgmt-modal"
     data-testid="column-mgmt-modal"
   />);
 });
@@ -56,7 +55,7 @@ describe('ColumnManagementModal component', () => {
   });
 
   it('should have checkbox checked if column is shown by default', () => {
-    const idCheckbox = screen.getByTestId('column-mgmt-modal').querySelector('input[type="checkbox"][aria-labelledby="synopsis"]');
+    const idCheckbox = screen.getByTestId('column-mgmt-modal').querySelector('input[type="checkbox"][aria-labelledby="id"]');
 
     expect(idCheckbox).toHaveAttribute('disabled');
     expect(idCheckbox).toHaveAttribute('checked');
@@ -66,8 +65,8 @@ describe('ColumnManagementModal component', () => {
     // disable Impact column which is enabled by default
     fireEvent.click(screen.getByText('Impact'));
 
-    // enable CVSS base score column which is disabled by default
-    fireEvent.click(screen.getByText('CVSS base score'));
+    // enable Score column which is disabled by default
+    fireEvent.click(screen.getByText('Score'));
 
     fireEvent.click(screen.getByText('Reset to default'));
   

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
@@ -9,7 +9,7 @@ const DEFAULT_COLUMNS : ColumnManagementModalColumn[] = [
     key: 'id',
     isShownByDefault: true,
     isShown: true,
-    isAlwaysShown: true
+    isUntoggleable: true
   },
   {
     title: 'Publish date',

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -33,20 +33,26 @@ export interface ColumnManagementModalColumn {
 
 export interface ColumnManagementModalProps extends Omit<ModalProps, 'ref' | 'children'> {
   /** Flag to show the modal */
-  isModalOpen: boolean,
+  isOpen?: boolean,
   /** Invoked when modal visibility is changed */
-  setModalOpen: (shouldOpen: boolean) => void
+  onClose?: (event: KeyboardEvent | React.MouseEvent) => void,
   /** Current column state */
   appliedColumns: ColumnManagementModalColumn[],
   /** Invoked with new column state after save button is clicked */
   applyColumns: (newColumns: ColumnManagementModalColumn[]) => void,
+  /* Modal description text */
+  description?: string,
+  /* Modal title text */
+  title?: string,
   /** Custom OUIA ID */
   ouiaId?: string | number,
 };
 
 const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps> = (
-  { isModalOpen,
-    setModalOpen,
+  { title = 'Manage columns',
+    description = 'Selected categories will be displayed in the table.',
+    isOpen = false,
+    onClose = () => undefined,
     appliedColumns,
     applyColumns,
     ouiaId = 'ColumnManagementModal',
@@ -77,25 +83,25 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
     setCurrentColumns(currentColumns.map(column => ({ ...column, isShown: column.isShownByDefault ?? false })));
   };
 
-  const handleSave = () => {
-    setModalOpen(false);
+  const handleSave = event => {
     applyColumns(currentColumns);
+    onClose(event);
   };
-
-  const handleCancel = () => {
-    setModalOpen(false);
+  
+  const handleCancel = event => {
     setCurrentColumns(appliedColumns.map(column => ({ ...column, isShown: column.isShown ?? column.isShownByDefault })));
+    onClose(event);
   };
 
   return (
     <Modal
-      title="Manage columns"
-      onClose={() => setModalOpen(false)}
-      isOpen={isModalOpen}
+      title={title}
+      onClose={onClose}
+      isOpen={isOpen}
       variant={ModalVariant.small}
       description={
         <TextContent>
-          <Text component={TextVariants.p}>Selected categories will be displayed in the table.</Text>
+          <Text component={TextVariants.p}>{description}</Text>
           <Split hasGutter>
             <SplitItem>
               <Button isInline onClick={selectAll} variant={ButtonVariant.link} ouiaId={`${ouiaId}-selectAll-button`}>

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -40,6 +40,8 @@ export interface ColumnManagementModalProps extends Omit<ModalProps, 'ref' | 'ch
   appliedColumns: ColumnManagementModalColumn[],
   /** Invoked with new column state after save button is clicked */
   applyColumns: (newColumns: ColumnManagementModalColumn[]) => void,
+  /** Custom OUIA ID */
+  ouiaId?: string | number,
 };
 
 const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps> = (
@@ -47,6 +49,7 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
     setModalOpen,
     appliedColumns,
     applyColumns,
+    ouiaId = 'ColumnManagementModal',
     ...props }: ColumnManagementModalProps) => {
 
   const [ currentColumns, setCurrentColumns ] = React.useState(
@@ -95,12 +98,12 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
           <Text component={TextVariants.p}>Selected categories will be displayed in the table.</Text>
           <Split hasGutter>
             <SplitItem>
-              <Button isInline onClick={selectAll} variant={ButtonVariant.link}>
+              <Button isInline onClick={selectAll} variant={ButtonVariant.link} ouiaId={`${ouiaId}-selectAll-button`}>
                 Select all
               </Button>
             </SplitItem>
             <SplitItem>
-              <Button isInline onClick={resetToDefault} variant={ButtonVariant.link}>
+              <Button isInline onClick={resetToDefault} variant={ButtonVariant.link} ouiaId={`${ouiaId}-reset-button`}>
                 Reset to default
               </Button>
             </SplitItem>
@@ -108,30 +111,32 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
         </TextContent>
       }
       actions={[
-        <Button key="save" variant={ButtonVariant.primary} onClick={handleSave}>
+        <Button key="save" variant={ButtonVariant.primary} onClick={handleSave} ouiaId={`${ouiaId}-save-button`}>
           Save
         </Button>,
-        <Button key="cancel" variant={ButtonVariant.link} onClick={handleCancel}>
+        <Button key="cancel" variant={ButtonVariant.link} onClick={handleCancel} ouiaId={`${ouiaId}-cancel-button`}>
           Cancel
         </Button>
       ]}
+      ouiaId={ouiaId}
       {...props}
     >
-      <DataList aria-label="Table column management" id="table-column-management" isCompact>
+      <DataList aria-label="Selected columns" isCompact data-ouia-component-id={`${ouiaId}-column-list`}>
         {currentColumns.map((column, index) =>
           <DataListItem key={column.key}>
             <DataListItemRow>
               <DataListCheck
-                aria-labelledby={column.key}
                 checked={column.isShown}
-                id={`checkbox-${index}`}
                 onChange={() => handleChange(index)}
                 isDisabled={column.isAlwaysShown}
+                aria-labelledby={`${ouiaId}-column${index}-label`}
+                data-ouia-component-id={`${ouiaId}-column${index}-checkbox`}
+                id={`${ouiaId}-column${index}-checkbox`}
               />
               <DataListItemCells
                 dataListCells={[
-                  <DataListCell key={`table-column-management-item-${index}`}>
-                    <label htmlFor={`checkbox-${index}`}>
+                  <DataListCell key={column.key} data-ouia-component-id={`${ouiaId}-column${index}-label`}>
+                    <label htmlFor={`${ouiaId}-column${index}-checkbox`} id={`${ouiaId}-column${index}-label`}>
                       {column.title}
                     </label>
                   </DataListCell>

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -13,7 +13,9 @@ import {
   DataListItemCells,
   Split,
   SplitItem,
-  ModalProps
+  ModalProps,
+  ButtonVariant,
+  ModalVariant
 } from '@patternfly/react-core';
 
 export interface ColumnManagementModalColumn {
@@ -87,18 +89,18 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
       title="Manage columns"
       onClose={() => setModalOpen(false)}
       isOpen={isModalOpen}
-      variant="small"
+      variant={ModalVariant.small}
       description={
         <TextContent>
           <Text component={TextVariants.p}>Selected categories will be displayed in the table.</Text>
           <Split hasGutter>
             <SplitItem>
-              <Button isInline onClick={selectAll} variant="link">
+              <Button isInline onClick={selectAll} variant={ButtonVariant.link}>
                 Select all
               </Button>
             </SplitItem>
             <SplitItem>
-              <Button isInline onClick={resetToDefault} variant="link">
+              <Button isInline onClick={resetToDefault} variant={ButtonVariant.link}>
                 Reset to default
               </Button>
             </SplitItem>
@@ -106,10 +108,10 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
         </TextContent>
       }
       actions={[
-        <Button key="save" variant="primary" onClick={handleSave}>
+        <Button key="save" variant={ButtonVariant.primary} onClick={handleSave}>
           Save
         </Button>,
-        <Button key="cancel" variant="secondary" onClick={handleCancel}>
+        <Button key="cancel" variant={ButtonVariant.link} onClick={handleCancel}>
           Cancel
         </Button>
       ]}
@@ -122,14 +124,14 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
               <DataListCheck
                 aria-labelledby={column.key}
                 checked={column.isShown}
-                id={'checkbox-' + index}
+                id={`checkbox-${index}`}
                 onChange={() => handleChange(index)}
                 isDisabled={column.isAlwaysShown}
               />
               <DataListItemCells
                 dataListCells={[
-                  <DataListCell key={'table-column-management-item' + index}>
-                    <label htmlFor={'checkbox-' + index}>
+                  <DataListCell key={`table-column-management-item-${index}`}>
+                    <label htmlFor={`checkbox-${index}`}>
                       {column.title}
                     </label>
                   </DataListCell>

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -27,8 +27,8 @@ export interface ColumnManagementModalColumn {
   isShown?: boolean,
   /** Set to false if the column should be hidden initially */
   isShownByDefault: boolean,
-  /** The checkbox will be checked and disabled, this is applicable to identifier columns which user shouldn't be able to hide */
-  isAlwaysShown?: boolean
+  /** The checkbox will be disabled, this is applicable to columns which should not be toggleable by user */
+  isUntoggleable?: boolean
 }
 
 export interface ColumnManagementModalProps extends Omit<ModalProps, 'ref' | 'children'> {
@@ -134,7 +134,7 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
               <DataListCheck
                 checked={column.isShown}
                 onChange={() => handleChange(index)}
-                isDisabled={column.isAlwaysShown}
+                isDisabled={column.isUntoggleable}
                 aria-labelledby={`${ouiaId}-column${index}-label`}
                 data-ouia-component-id={`${ouiaId}-column${index}-checkbox`}
                 id={`${ouiaId}-column${index}-checkbox`}

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import {
+  Modal,
+  Button,
+  TextContent,
+  Text,
+  TextVariants,
+  DataListItem,
+  DataList,
+  DataListItemRow,
+  DataListCheck,
+  DataListCell,
+  DataListItemCells,
+  Split,
+  SplitItem,
+  ModalProps
+} from '@patternfly/react-core';
+
+export interface ColumnManagementModalColumn {
+  /** Internal identifier of a column by which table displayed columns are filtered. */
+  key: string,
+  /** The actual display name of the column possibly with a tooltip or icon. */
+  title: React.ReactNode,
+  /** If user changes checkboxes, the component will send back column array with this property altered. */
+  isShown?: boolean,
+  /** Set to false if the column should be hidden initially */
+  isShownByDefault: boolean,
+  /** The checkbox will be checked and disabled, this is applicable to identifier columns which user shouldn't be able to hide */
+  isAlwaysShown?: boolean
+}
+
+export interface ColumnManagementModalProps extends Omit<ModalProps, 'ref' | 'children'> {
+  /** Flag to show the modal */
+  isModalOpen: boolean,
+  /** Invoked when modal visibility is changed */
+  setModalOpen: (shouldOpen: boolean) => void
+  /** Current column state */
+  appliedColumns: ColumnManagementModalColumn[],
+  /** Invoked with new column state after save button is clicked */
+  applyColumns: (newColumns: ColumnManagementModalColumn[]) => void,
+};
+
+const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps> = (
+  { isModalOpen,
+    setModalOpen,
+    appliedColumns,
+    applyColumns,
+    ...props }: ColumnManagementModalProps) => {
+
+  const [ currentColumns, setCurrentColumns ] = React.useState(
+    appliedColumns.map(column => ({ ...column, isShown: column.isShown ?? column.isShownByDefault }))
+  );
+
+  const handleChange = index => {
+    const newColumns = [ ...currentColumns ];
+    const changedColumn = { ...newColumns[index] };
+
+    changedColumn.isShown = !changedColumn.isShown;
+    newColumns[index] = changedColumn;
+
+    setCurrentColumns(newColumns);
+  };
+
+  const selectAll = () => {
+    let newColumns = [ ...currentColumns ];
+    newColumns = newColumns.map(column => ({ ...column, isShown: true }));
+
+    setCurrentColumns(newColumns);
+  };
+
+  const resetToDefault = () => {
+    setCurrentColumns(currentColumns.map(column => ({ ...column, isShown: column.isShownByDefault ?? false })));
+  };
+
+  const handleSave = () => {
+    setModalOpen(false);
+    applyColumns(currentColumns);
+  };
+
+  const handleCancel = () => {
+    setModalOpen(false);
+    setCurrentColumns(appliedColumns.map(column => ({ ...column, isShown: column.isShown ?? column.isShownByDefault })));
+  };
+
+  return (
+    <Modal
+      title="Manage columns"
+      onClose={() => setModalOpen(false)}
+      isOpen={isModalOpen}
+      variant="small"
+      description={
+        <TextContent>
+          <Text component={TextVariants.p}>Selected categories will be displayed in the table.</Text>
+          <Split hasGutter>
+            <SplitItem>
+              <Button isInline onClick={selectAll} variant="link">
+                Select all
+              </Button>
+            </SplitItem>
+            <SplitItem>
+              <Button isInline onClick={resetToDefault} variant="link">
+                Reset to default
+              </Button>
+            </SplitItem>
+          </Split>
+        </TextContent>
+      }
+      actions={[
+        <Button key="save" variant="primary" onClick={handleSave}>
+          Save
+        </Button>,
+        <Button key="cancel" variant="secondary" onClick={handleCancel}>
+          Cancel
+        </Button>
+      ]}
+      {...props}
+    >
+      <DataList aria-label="Table column management" id="table-column-management" isCompact>
+        {currentColumns.map((column, index) =>
+          <DataListItem key={column.key}>
+            <DataListItemRow>
+              <DataListCheck
+                aria-labelledby={column.key}
+                checked={column.isShown}
+                id={'checkbox-' + index}
+                onChange={() => handleChange(index)}
+                isDisabled={column.isAlwaysShown}
+              />
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key={'table-column-management-item' + index}>
+                    <label htmlFor={'checkbox-' + index}>
+                      {column.title}
+                    </label>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+        )}
+      </DataList>
+    </Modal>
+  );
+}
+
+export default ColumnManagementModal;

--- a/packages/module/src/ColumnManagementModal/index.ts
+++ b/packages/module/src/ColumnManagementModal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ColumnManagementModal';
+export * from './ColumnManagementModal';

--- a/packages/module/src/index.ts
+++ b/packages/module/src/index.ts
@@ -15,6 +15,9 @@ export * from './Battery';
 export { default as CloseButton } from './CloseButton';
 export * from './CloseButton';
 
+export { default as ColumnManagementModal } from './ColumnManagementModal';
+export * from './ColumnManagementModal';
+
 export { default as DetailsPage } from './DetailsPage';
 export * from './DetailsPage';
 


### PR DESCRIPTION
# Column Management Modal

Associated ticket: [RHINENG-3003](https://issues.redhat.com/browse/RHINENG-3003)

## What

Implement a modal that a user can use to configure the visibility of individual table columns. The modal supports columns that are hidden by default and also those that should be unhideable.

![image](https://github.com/patternfly/react-component-groups/assets/50696716/c5cadbea-fb3f-4a19-b55c-41f606f3fff1)

[Screencastfrom2024-04-1216-04-18-ezgif.com-video-to-gif-converter.webm](https://github.com/patternfly/react-component-groups/assets/8426204/268280f5-357e-48f1-a780-cb26b339bfef)

## Why
Since there is a request (see the associated ticket above) to implement column management in tables in all apps across Insights it would make sense to abstract a component that could be reused. Currently, the only implementation of column management is in [Insights Vulnerability](https://console.redhat.com/insights/vulnerability) (hidden inside kebab menu in table toolbar). This PR is based on the Vulnerability's implementation inspired by the [PF column management demo](https://www.patternfly.org/components/table/react-demos/column-management/).

## Example usage in practice with Redux

```js
// Hooks file
export const useColumnManagement = (columns, onApply) => {
    const [isModalOpen, setModalOpen] = useState(false);

    return [(
        <ColumnManagementModal
            appliedColumns={columns}
            applyColumns={newColumns => onApply(newColumns)}
            isModalOpen={isModalOpen}
            setModalOpen={setModalOpen}
        />), setModalOpen];
};

// Table file
const columns = useSelector(({ TableStore }) => TableStore.columns;
const [ColumnManagementModal, setColumnManagementModalOpen] = 
    useColumnManagement(columns, newColumns => dispatch(changeTableAction(newColumns)));

return (
    ...
    <Button onClick={() => setColumnManagementModalOpen(true)}>Manage columns</Button>
    ...
    { ColumnManagementModal }
    ...
)
```