### PR TITLE
Add props for sort indicators, checkboxes and expand to Skeleton Table

### DIFF
--- a/cypress/component/SkeletonTable.cy.tsx
+++ b/cypress/component/SkeletonTable.cy.tsx
@@ -1,11 +1,70 @@
 import React from 'react';
+import { Th } from '@patternfly/react-table';
 import SkeletonTable from '../../packages/module/dist/dynamic/SkeletonTable';
 
 describe('SkeletonTable', () => {
+  beforeEach(() => {
+    cy.viewport(1600, 800);
+  });
+
   it('renders SkeletonTable', () => {
-    const SkeletonTableExample =  <SkeletonTable rowSize={10} columns={[ 'first', 'second' ]} />;
+    const SkeletonTableExample = <SkeletonTable rows={10} columns={[ 'first', 'second' ]} />;
     cy.mount(SkeletonTableExample);
     cy.get('table').should('exist');
     cy.get('table thead tr').should('have.text', 'firstsecond');
   });
-})
+
+  it ('can be used without passing columns', () => {
+    const SkeletonTableExample = <SkeletonTable rows={10} numberOfColumns={2} />;
+    cy.mount(SkeletonTableExample);
+    cy.get('table').should('exist');
+    cy.get('table thead tr').should('have.text', '');
+  });
+
+  it('contains checkboxes when passed isSelectable', () => {
+    const SkeletonTableExample = <SkeletonTable rows={10} columns={[ 'first', 'second' ]} isSelectable />;
+    cy.mount(SkeletonTableExample);
+    cy.get('table').should('exist');
+    cy.get('table thead tr').should('have.text', 'firstsecond');
+    cy.get('input[type="checkbox"]').should('have.length', 10);
+  });
+
+  it('is expandable when passed isExpandable', () => {
+    const SkeletonTableExample = <SkeletonTable rows={10} columns={[ 'first', 'second' ]} isExpandable />;
+    cy.mount(SkeletonTableExample);
+    cy.get('table').should('exist');
+    cy.get('table thead tr').should('have.text', 'firstsecond');
+    cy.get('.pf-v5-c-table__toggle-icon').should('have.length', 10);
+  });
+
+  it('can be passed a selectVariant to render radio buttons', () => {
+    const SkeletonTableExample = <SkeletonTable rows={10} columns={[ 'first', 'second' ]} isSelectable selectVariant="radio" />;
+    cy.mount(SkeletonTableExample);
+    cy.get('table').should('exist');
+    cy.get('table thead tr').should('have.text', 'firstsecond');
+    cy.get('input[type="radio"]').should('have.length', 10);
+  });
+
+  it('can be passed custom columns', () => {
+    const SkeletonTableExample = (
+      <SkeletonTable
+        rows={10}
+        columns={[
+          <Th key="1" sort={{ columnIndex: 0, sortBy: { index: 0, direction: 'asc' } }}>
+            first
+          </Th>,
+          <Th key="2">second</Th>,
+          <Th key="3">third</Th>
+        ]}
+      />
+    );
+    cy.mount(SkeletonTableExample);
+    cy.get('table').should('exist');
+    cy.get('table thead tr').should('have.text', 'firstsecondthird');
+    cy.get('.pf-v5-c-table__sort-indicator').eq(0).find('path').should(
+      'have.attr',
+      'd',
+      'M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z' // ascending
+    );
+  })
+});

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/Skeleton.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/Skeleton.md
@@ -27,6 +27,38 @@ To indicate that a table's cells are still loading, a basic skeleton table uses 
 
 ```
 
+### Compact skeleton table
+
+The skeleton table can be displayed as a compact table by setting the `variant` prop to `compact`. Borders can be toggled off by setting `borders` to `false`.
+
+```js file="./SkeletonTableCompactExample.tsx"
+
+```
+
+### Selectable columns
+
+The skeleton table can display selectable columns by setting the `isSelectable` prop to `true`. The `selectVariant` prop determines if radio buttons or checkboxes are used.
+
+```js file="./SkeletonTableSelectableExample.tsx"
+
+```
+
+### Expandable rows
+
+The skeleton table can display the indicator for expandable rows by setting the `isExpandable` prop to `true`.
+
+```js file="./SkeletonTableExpandableExample.tsx"
+
+```
+
+### Customizable column headers
+
+Custom column headers can be provided by passing an array of strings or `Th` components to the `columns` prop instead of an array of strings. This allows you to support sorting on columns, add custom content, or style the column headers.
+
+```js file="./SkeletonTableCustomExample.tsx"
+
+```
+
 ### Full loading simulation
 
 The following example demonstrates the typical behavior of a skeleton table transitioning to a normal table as the data becomes available.

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/SkeletonTableCompactExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/SkeletonTableCompactExample.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import SkeletonTable from '@patternfly/react-core/dist/js/components/Skeleton/SkeletonTable';
+
+export const SkeletonTableExample: React.FC = () => <SkeletonTable rowSize={10} columns={[ 'first', 'second' ]} variant='compact' borders={false} />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/SkeletonTableCustomExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/SkeletonTableCustomExample.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import SkeletonTable from '@patternfly/react-core/dist/js/components/Skeleton/SkeletonTable';
+import { Th } from '@patternfly/react-table';
+
+export const SkeletonTableExample: React.FC = () => (
+  <SkeletonTable
+    rowSize={10}
+    columns={[
+      <Th key="1" sort={{ columnIndex: 0, sortBy: {} }}>
+        first
+      </Th>,
+      <Th key="2" sort={{ columnIndex: 1, sortBy: {} }}>
+        second
+      </Th>
+    ]}
+  />
+);

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/SkeletonTableExpandableExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/SkeletonTableExpandableExample.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import SkeletonTable from '@patternfly/react-core/dist/js/components/Skeleton/SkeletonTable';
+
+export const SkeletonTableExample: React.FC = () => <SkeletonTable rowSize={10} columns={[ 'first', 'second' ]} isExpandable />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/SkeletonTableSelectableExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Skeleton/SkeletonTableSelectableExample.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import SkeletonTable from '@patternfly/react-core/dist/js/components/Skeleton/SkeletonTable';
+
+export const SkeletonTableExample: React.FC = () => (
+  <SkeletonTable rowSize={10} columns={[ 'first', 'second' ]} isSelectable selectVariant="radio" />
+);

--- a/packages/module/src/SkeletonTable/SkeletonTable.tsx
+++ b/packages/module/src/SkeletonTable/SkeletonTable.tsx
@@ -1,38 +1,80 @@
-import React, { ReactNode } from 'react';
-import { Caption, Table, TableProps, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import React from 'react';
+import {
+  Caption,
+  Table,
+  TableProps,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  RowSelectVariant
+} from '@patternfly/react-table';
 import { Skeleton } from '@patternfly/react-core';
 
-export type SkeletonTableProps = Omit<TableProps, 'ref'> & {
+export interface SkeletonTableProps extends Omit<TableProps, 'ref'> {
   /** Indicates the table variant */
   variant?: TableVariant;
+  /** Flag indicating if the table should have borders */
+  borders?: boolean;
   /** The number of rows the skeleton table should contain */
   rows?: number;
   /** Any captions that should be added to the table */
-  caption?: ReactNode;
+  caption?: React.ReactNode;
   /** Custom OUIA ID */
   ouiaId?: string | number;
-} & (
-    | {
-        columns: ReactNode[];
-      }
-    | {
-        numberOfColumns: number;
-      }
-  );
-
-
-function hasCustomColumns(props: Record<string, any>): props is SkeletonTableProps & {
-  columns: ReactNode[];
-} {
-  return Array.isArray(props.columns);
+  /** Flag indicating if the table is selectable */
+  isSelectable?: boolean;
+  /** Flag indicating if the table is expandable */
+  isExpandable?: boolean;
+  /** Determines if the row is selectable using radio or checkbox */
+  selectVariant?: RowSelectVariant;
+  /** Custom columns for the table */
+  columns?: string[] | React.ReactElement<typeof Th>[];
+  /** Number of columns in the table */
+  numberOfColumns?: number;
 }
 
-const SkeletonTable: React.FunctionComponent<SkeletonTableProps> = (props: SkeletonTableProps) => {
-  const { variant, rows = 5, caption, ouiaId = 'SkeletonTable', ...rest } = props;
-  const rowCells = hasCustomColumns(props) ? props.columns.length : props.numberOfColumns;
+const SkeletonTable: React.FunctionComponent<SkeletonTableProps> = ({
+  variant,
+  borders = true,
+  rows = 5,
+  caption,
+  ouiaId = 'SkeletonTable',
+  isSelectable,
+  isExpandable,
+  selectVariant = RowSelectVariant.checkbox,
+  columns,
+  numberOfColumns,
+  ...rest
+}: SkeletonTableProps) => {
+  const hasCustomColumns = Array.isArray(columns);
+  const rowCells = hasCustomColumns ? columns?.length ?? 0 : numberOfColumns;
   const rowArray = [ ...new Array(rowCells) ];
+
   const bodyRows = [ ...new Array(rows) ].map((_, rowIndex) => (
     <Tr key={rowIndex} ouiaId={`${ouiaId}-tr-${rowIndex}`}>
+      {isExpandable && (
+        <Td
+          data-ouia-component-id={`${ouiaId}-td-expand-${rowIndex}`}
+          expand={{
+            rowIndex,
+            isExpanded: false
+          }}
+        />
+      )}
+      {isSelectable && (
+        <Td
+          data-ouia-component-id={`${ouiaId}-td-select-${rowIndex}`}
+          select={{
+            rowIndex,
+            isSelected: false,
+            isDisabled: true,
+            variant: selectVariant
+          }}
+        />
+      )}
       {rowArray.map((_, colIndex) => (
         <Td key={colIndex} data-ouia-component-id={`${ouiaId}-td-${rowIndex}-${colIndex}`}>
           <Skeleton />
@@ -42,12 +84,22 @@ const SkeletonTable: React.FunctionComponent<SkeletonTableProps> = (props: Skele
   ));
 
   return (
-    <Table aria-label="Loading" variant={variant} ouiaId={ouiaId} {...rest}>
+    <Table aria-label="Loading" variant={variant} borders={borders} ouiaId={ouiaId} {...rest}>
       {caption && <Caption>{caption}</Caption>}
       <Thead data-ouia-component-id={`${ouiaId}-thead`}>
         <Tr ouiaId={`${ouiaId}-tr-head`}>
-          {hasCustomColumns(props)
-            ? props.columns.map((c, index) => <Th key={index} data-ouia-component-id={`${ouiaId}-th-${index}`}>{c}</Th>)
+          {isExpandable && <Th key="expand" />}
+          {isSelectable && <Th key="select" />}
+          {hasCustomColumns
+            ? columns?.map((c, index) =>
+              typeof c === 'string' ? (
+                <Th key={index} data-ouia-component-id={`${ouiaId}-th-${index}`}>
+                  {c}
+                </Th>
+              ) : (
+                React.cloneElement(c, { key: index, 'data-ouia-component-id': `${ouiaId}-th-${index}` })
+              )
+            )
             : rowArray.map((_, index) => (
               <Th key={index} data-ouia-component-id={`${ouiaId}-th-${index}`}>
                 <Skeleton />

--- a/packages/module/src/SkeletonTable/SkeletonTable.tsx
+++ b/packages/module/src/SkeletonTable/SkeletonTable.tsx
@@ -28,7 +28,7 @@ export interface SkeletonTableProps extends Omit<TableProps, 'ref'> {
   isSelectable?: boolean;
   /** Flag indicating if the table is expandable */
   isExpandable?: boolean;
-  /** Determines if the row is selectable using radio or checkbox */
+  /** Determines if the row selection variant (radio/checkbox) */
   selectVariant?: RowSelectVariant;
   /** Custom columns for the table */
   columns?: string[] | React.ReactElement<typeof Th>[];

--- a/packages/module/src/SkeletonTable/__snapshots__/SkeletonTable.test.tsx.snap
+++ b/packages/module/src/SkeletonTable/__snapshots__/SkeletonTable.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`SkeletonTable component should render correctly 1`] = `
       <table
         aria-label="Loading"
         class="pf-v5-c-table pf-m-grid-md"
-        columns="first,second"
         data-ouia-component-id="SkeletonTable"
         data-ouia-component-type="PF5/Table"
         data-ouia-safe="true"
@@ -220,7 +219,6 @@ exports[`SkeletonTable component should render correctly 1`] = `
     <table
       aria-label="Loading"
       class="pf-v5-c-table pf-m-grid-md"
-      columns="first,second"
       data-ouia-component-id="SkeletonTable"
       data-ouia-component-type="PF5/Table"
       data-ouia-safe="true"
@@ -489,7 +487,6 @@ exports[`SkeletonTable component should render correctly with rows 1`] = `
       <table
         aria-label="Loading"
         class="pf-v5-c-table pf-m-grid-md"
-        columns="first,second"
         data-ouia-component-id="SkeletonTable"
         data-ouia-component-type="PF5/Table"
         data-ouia-safe="true"
@@ -701,7 +698,6 @@ exports[`SkeletonTable component should render correctly with rows 1`] = `
     <table
       aria-label="Loading"
       class="pf-v5-c-table pf-m-grid-md"
-      columns="first,second"
       data-ouia-component-id="SkeletonTable"
       data-ouia-component-type="PF5/Table"
       data-ouia-safe="true"


### PR DESCRIPTION
![image](https://github.com/patternfly/react-component-groups/assets/39098327/aa29f533-d554-4469-8e97-e1862d45f58b)

Added the following props to the SkeletonTable component ([RHCLOUD-32382](https://issues.redhat.com/browse/RHCLOUD-32382)):

- `isSelectable`: A boolean prop that determines whether the table rows are selectable. When set to true, checkboxes will be rendered in a column to the left side.
- `isExpandable`: A boolean prop that indicates whether the table rows are expandable. When set to true, a caret expand indicator will be rendered in a column to the left side.
- `sortBy`: An object that specifies the sort column and direction for the table. It has the following shape:
    ```
    {
      index: number;
      direction: 'asc' | 'desc';
    }
    ```

    - `index` represents the index of the column to sort by.
    - `direction` indicates the sort direction, either `'asc'` for ascending order or `'desc'` for descending order.