### PR TITLE
Margin and fontSize alignment of TagCount

### DIFF
--- a/packages/module/src/TagCount/TagCount.tsx
+++ b/packages/module/src/TagCount/TagCount.tsx
@@ -12,7 +12,8 @@ const useStyles = createUseStyles({
   },
 
   tagText: {
-    marginLeft: 10
+    marginLeft: 'var(--pf-v5-global--spacer--sm)',
+    fontSize: 'var(--pf-v5-global--FontSize--sm)'
   }
 });
 


### PR DESCRIPTION
[RHINENG-7746](https://issues.redhat.com/browse/RHINENG-7746)

The tag number and icon seems to be misaligned and font-size is off in the context of surrounding content. 

Before:
fontSize: 16px
margin: 10px
<img width="396" alt="image" src="https://github.com/user-attachments/assets/8a607341-c44a-4b5f-93a2-1b30cbd6f120">

After:
fontSize: 14px
margin: 6px
<img width="385" alt="image" src="https://github.com/user-attachments/assets/4e10b8ab-bbd6-4553-853c-9c35a673b615">

Any changes or improvements to this PR are welcome.