### PR TITLE
Status styling fixes

### DIFF
--- a/packages/module/src/Status/Status.tsx
+++ b/packages/module/src/Status/Status.tsx
@@ -45,7 +45,8 @@ export interface StatusProps extends React.PropsWithChildren {
 
 const useStyles = createUseStyles({
   icon: {
-    margin: 0
+    margin: "0",
+    alignSelf: "flex-start",
   },
   statusLabel: {
     lineHeight: 'var(--pf-v6-global--LineHeight--sm)',
@@ -67,7 +68,7 @@ export const Status: React.FC<StatusProps> = ({ variant = StatusVariant.plain, l
     <Flex title={label} alignItems={{ default: 'alignItemsCenter' }} {...props}>
       {icon && (
         <FlexItem className={classes.icon}>
-          <Icon className='pf-v6-u-mr-md' status={status} title={iconTitle ?? status} data-ouia-component-id={`${ouiaId}-icon`}>
+          <Icon className='pf-v6-u-mr-sm' status={status} title={iconTitle ?? status} data-ouia-component-id={`${ouiaId}-icon`}>
             {icon}
           </Icon>
         </FlexItem>

--- a/packages/module/src/Status/__snapshots__/Status.test.tsx.snap
+++ b/packages/module/src/Status/__snapshots__/Status.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Status component should render correctly 1`] = `
           class="icon-0-2-1"
         >
           <span
-            class="pf-v6-c-icon pf-v6-u-mr-md"
+            class="pf-v6-c-icon pf-v6-u-mr-sm"
             data-ouia-component-id="Status-icon"
             title="warning"
           >
@@ -62,7 +62,7 @@ exports[`Status component should render correctly 1`] = `
         class="icon-0-2-1"
       >
         <span
-          class="pf-v6-c-icon pf-v6-u-mr-md"
+          class="pf-v6-c-icon pf-v6-u-mr-sm"
           data-ouia-component-id="Status-icon"
           title="warning"
         >
@@ -180,7 +180,7 @@ exports[`Status component should render correctly link 1`] = `
               class="icon-0-2-1"
             >
               <span
-                class="pf-v6-c-icon pf-v6-u-mr-md"
+                class="pf-v6-c-icon pf-v6-u-mr-sm"
                 data-ouia-component-id="Status-icon"
                 title="success"
               >
@@ -243,7 +243,7 @@ exports[`Status component should render correctly link 1`] = `
             class="icon-0-2-1"
           >
             <span
-              class="pf-v6-c-icon pf-v6-u-mr-md"
+              class="pf-v6-c-icon pf-v6-u-mr-sm"
               data-ouia-component-id="Status-icon"
               title="success"
             >
@@ -366,7 +366,7 @@ exports[`Status component should render correctly popover 1`] = `
                 class="icon-0-2-1"
               >
                 <span
-                  class="pf-v6-c-icon pf-v6-u-mr-md"
+                  class="pf-v6-c-icon pf-v6-u-mr-sm"
                   data-ouia-component-id="Status-icon"
                   title="danger"
                 >
@@ -433,7 +433,7 @@ exports[`Status component should render correctly popover 1`] = `
               class="icon-0-2-1"
             >
               <span
-                class="pf-v6-c-icon pf-v6-u-mr-md"
+                class="pf-v6-c-icon pf-v6-u-mr-sm"
                 data-ouia-component-id="Status-icon"
                 title="danger"
               >
@@ -542,7 +542,7 @@ exports[`Status component should render correctly with description 1`] = `
           class="icon-0-2-1"
         >
           <span
-            class="pf-v6-c-icon pf-v6-u-mr-md"
+            class="pf-v6-c-icon pf-v6-u-mr-sm"
             data-ouia-component-id="Status-icon"
             title="warning"
           >
@@ -600,7 +600,7 @@ exports[`Status component should render correctly with description 1`] = `
         class="icon-0-2-1"
       >
         <span
-          class="pf-v6-c-icon pf-v6-u-mr-md"
+          class="pf-v6-c-icon pf-v6-u-mr-sm"
           data-ouia-component-id="Status-icon"
           title="warning"
         >
@@ -715,7 +715,7 @@ exports[`Status component should render iconOnly correctly 1`] = `
           class="icon-0-2-1"
         >
           <span
-            class="pf-v6-c-icon pf-v6-u-mr-md"
+            class="pf-v6-c-icon pf-v6-u-mr-sm"
             data-ouia-component-id="Status-icon"
             title="1 security issue found"
           >
@@ -750,7 +750,7 @@ exports[`Status component should render iconOnly correctly 1`] = `
         class="icon-0-2-1"
       >
         <span
-          class="pf-v6-c-icon pf-v6-u-mr-md"
+          class="pf-v6-c-icon pf-v6-u-mr-sm"
           data-ouia-component-id="Status-icon"
           title="1 security issue found"
         >


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-34198
https://github.com/patternfly/react-component-groups/issues/218

- Top align status icon
- Set padding to 8px

Old
<img width="691" alt="Screenshot 2024-08-05 at 9 09 25 AM" src="https://github.com/user-attachments/assets/8d9794cf-8b5a-47cf-915d-ff7782bed01b">

New
<img width="753" alt="Screenshot 2024-08-05 at 9 07 38 AM" src="https://github.com/user-attachments/assets/670b0ebe-d748-4eb8-92d6-f5a23b36ff2a">
