### PR TITLE
Unavalable Content button change

### DIFF
--- a/packages/module/src/UnavailableContent/UnavailableContent.tsx
+++ b/packages/module/src/UnavailableContent/UnavailableContent.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
-import { Button, EmptyState, EmptyStateBody, EmptyStateProps, EmptyStateStatus, EmptyStateVariant } from '@patternfly/react-core';
+import { Button, EmptyState, EmptyStateBody, EmptyStateFooter, EmptyStateProps, EmptyStateStatus, EmptyStateVariant } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { createUseStyles } from 'react-jss';
-
-const useStyles = createUseStyles({
-  emptyStateLinkButton: {
-    padding: '0',
-    fontSize: 'var(--pf-v6-c-empty-state--body--FontSize)'
-  }
-});
 
 export interface UnavailableContentProps extends Omit<EmptyStateProps, 'children' | 'titleText' | 'bodyText'> {
   /** The URL that the status page link points to */
@@ -17,35 +9,30 @@ export interface UnavailableContentProps extends Omit<EmptyStateProps, 'children
   statusPageLinkText?: string;
   /** The title for the unavailable content message */
   titleText?: string;
-  /** The body text for the unavailable content message that appears before the status page link */
-  preLinkBodyText?: string;
-  /** The body text for the unavailable content message that appears after the status page link */
-  postLinkBodyText?: string;
+  /** The body text for the unavailable content message */
+  bodyText?: string;
   /** Custom OUIA ID */
   ouiaId?: string | number;
 }
 
 const UnavailableContent: React.FunctionComponent<UnavailableContentProps> = ({ 
   statusPageUrl = '',
-  statusPageLinkText = 'status page',
+  statusPageLinkText = 'Status Page',
   titleText = 'This page is temporarily unavailable',
-  preLinkBodyText = 'Try refreshing the page. If the problem persists, contact your organization administrator or visit our',
-  postLinkBodyText = 'for known outages.',
+  bodyText = 'Try refreshing the page. If the problem persists, contact your organization administrator or visit our status page for known outages.',
   ouiaId = 'UnavailableContent',
   ...props 
-}: UnavailableContentProps) => {
-  const classes = useStyles();
-  return (
-    <EmptyState headingLevel="h5" status={EmptyStateStatus.danger} icon={ExclamationCircleIcon}  titleText={titleText} variant={EmptyStateVariant.lg} data-ouia-component-id={ouiaId} {...props}>
-      <EmptyStateBody data-ouia-component-id={`${ouiaId}-body`}>
-        {preLinkBodyText}{' '}
-        <Button component='a' className={classes.emptyStateLinkButton} variant='link' href={statusPageUrl} target="_blank" rel="noopener noreferrer" ouiaId={`${ouiaId}-link-button`}>
-          {statusPageLinkText}
-        </Button>{' '}
-        {postLinkBodyText}
-      </EmptyStateBody>
-    </EmptyState>
-  );
-};
+}: UnavailableContentProps) => (
+  <EmptyState headingLevel="h5" status={EmptyStateStatus.danger} icon={ExclamationCircleIcon}  titleText={titleText} variant={EmptyStateVariant.lg} data-ouia-component-id={ouiaId} {...props}>
+    <EmptyStateBody data-ouia-component-id={`${ouiaId}-body`}>
+      {bodyText}
+    </EmptyStateBody>
+    <EmptyStateFooter data-ouia-component-id={`${ouiaId}-footer`}>
+      <Button component='a' variant='primary' href={statusPageUrl} target="_blank" rel="noopener noreferrer" ouiaId={`${ouiaId}-link-button`}>
+        {statusPageLinkText}
+      </Button>
+    </EmptyStateFooter>
+  </EmptyState>
+);
 
 export default UnavailableContent;

--- a/packages/module/src/UnavailableContent/__snapshots__/UnavailableContent.test.tsx.snap
+++ b/packages/module/src/UnavailableContent/__snapshots__/UnavailableContent.test.tsx.snap
@@ -46,11 +46,15 @@ exports[`Unavailable component should render with a link 1`] = `
             class="pf-v6-c-empty-state__body"
             data-ouia-component-id="UnavailableContent-body"
           >
-            Try refreshing the page. If the problem persists, contact your organization administrator or visit our
-             
+            Try refreshing the page. If the problem persists, contact your organization administrator or visit our status page for known outages.
+          </div>
+          <div
+            class="pf-v6-c-empty-state__footer"
+            data-ouia-component-id="UnavailableContent-footer"
+          >
             <a
               aria-disabled="false"
-              class="pf-v6-c-button pf-m-link emptyStateLinkButton-0-2-1"
+              class="pf-v6-c-button pf-m-primary"
               data-ouia-component-id="UnavailableContent-link-button"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
@@ -61,11 +65,9 @@ exports[`Unavailable component should render with a link 1`] = `
               <span
                 class="pf-v6-c-button__text"
               >
-                status page
+                Status Page
               </span>
             </a>
-             
-            for known outages.
           </div>
         </div>
       </div>
@@ -113,11 +115,15 @@ exports[`Unavailable component should render with a link 1`] = `
           class="pf-v6-c-empty-state__body"
           data-ouia-component-id="UnavailableContent-body"
         >
-          Try refreshing the page. If the problem persists, contact your organization administrator or visit our
-           
+          Try refreshing the page. If the problem persists, contact your organization administrator or visit our status page for known outages.
+        </div>
+        <div
+          class="pf-v6-c-empty-state__footer"
+          data-ouia-component-id="UnavailableContent-footer"
+        >
           <a
             aria-disabled="false"
-            class="pf-v6-c-button pf-m-link emptyStateLinkButton-0-2-1"
+            class="pf-v6-c-button pf-m-primary"
             data-ouia-component-id="UnavailableContent-link-button"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
@@ -128,11 +134,9 @@ exports[`Unavailable component should render with a link 1`] = `
             <span
               class="pf-v6-c-button__text"
             >
-              status page
+              Status Page
             </span>
           </a>
-           
-          for known outages.
         </div>
       </div>
     </div>
@@ -237,11 +241,15 @@ exports[`Unavailable component should render with no link 1`] = `
             class="pf-v6-c-empty-state__body"
             data-ouia-component-id="UnavailableContent-body"
           >
-            Try refreshing the page. If the problem persists, contact your organization administrator or visit our
-             
+            Try refreshing the page. If the problem persists, contact your organization administrator or visit our status page for known outages.
+          </div>
+          <div
+            class="pf-v6-c-empty-state__footer"
+            data-ouia-component-id="UnavailableContent-footer"
+          >
             <a
               aria-disabled="false"
-              class="pf-v6-c-button pf-m-link emptyStateLinkButton-0-2-1"
+              class="pf-v6-c-button pf-m-primary"
               data-ouia-component-id="UnavailableContent-link-button"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
@@ -252,11 +260,9 @@ exports[`Unavailable component should render with no link 1`] = `
               <span
                 class="pf-v6-c-button__text"
               >
-                status page
+                Status Page
               </span>
             </a>
-             
-            for known outages.
           </div>
         </div>
       </div>
@@ -304,11 +310,15 @@ exports[`Unavailable component should render with no link 1`] = `
           class="pf-v6-c-empty-state__body"
           data-ouia-component-id="UnavailableContent-body"
         >
-          Try refreshing the page. If the problem persists, contact your organization administrator or visit our
-           
+          Try refreshing the page. If the problem persists, contact your organization administrator or visit our status page for known outages.
+        </div>
+        <div
+          class="pf-v6-c-empty-state__footer"
+          data-ouia-component-id="UnavailableContent-footer"
+        >
           <a
             aria-disabled="false"
-            class="pf-v6-c-button pf-m-link emptyStateLinkButton-0-2-1"
+            class="pf-v6-c-button pf-m-primary"
             data-ouia-component-id="UnavailableContent-link-button"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
@@ -319,11 +329,9 @@ exports[`Unavailable component should render with no link 1`] = `
             <span
               class="pf-v6-c-button__text"
             >
-              status page
+              Status Page
             </span>
           </a>
-           
-          for known outages.
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-34196
closes #220 
Removed link button and replaced by primary button. Button was moved to the Footer section. Removed unnecessary styling.

<img width="677" alt="image" src="https://github.com/user-attachments/assets/feb99de6-c645-4d5d-9c6d-746250a74d5c">
