### PR TITLE
make ServiceCard subtitle prop optional

### DIFF
--- a/packages/module/src/ServiceCard/ServiceCard.tsx
+++ b/packages/module/src/ServiceCard/ServiceCard.tsx
@@ -8,8 +8,8 @@ import clsx from 'clsx';
 export interface ServiceCardProps extends CardProps {
   /** Service card title */
   title: string;
-  /** Service card subtitle */
-  subtitle: string;
+  /** Optional Service card subtitle */
+  subtitle?: string;
   /** Service card description */
   description: string;
   /** Service card icon */
@@ -60,7 +60,7 @@ const ServiceCard: React.FunctionComponent<ServiceCardProps> = ({
           <FlexItem>
             <TextContent>
               <Text component={TextVariants.h2} ouiaId={`${ouiaId}-title`}>{title}</Text>
-              {subtitle}
+              {subtitle ? subtitle : null}
             </TextContent>
           </FlexItem>
         </Flex>


### PR DESCRIPTION
There are use cases when `subtitle` prop is not needed so I'm making it optional