### PR TITLE
fix(v6): Details page updates

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/DetailsPage/DetailsPageExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/DetailsPage/DetailsPageExample.tsx
@@ -29,8 +29,7 @@ export const BasicExample: React.FunctionComponent = () => (
         title: 'example-resource',
         label: {
           children: 'Ready',
-          icon: <CheckCircleIcon color="#3E8635" />,
-          isCompact: true,
+          icon: <CheckCircleIcon color="#3E8635" />
         },
       }}
       actionButtons={[

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/DetailsPage/DetailsPageHeaderExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/DetailsPage/DetailsPageHeaderExample.tsx
@@ -29,8 +29,7 @@ export const BasicExample: React.FunctionComponent = () => (
         title: 'example-resource',
         label: {
           children: 'Ready',
-          icon: <CheckCircleIcon color="#3E8635" />,
-          isCompact: true,
+          icon: <CheckCircleIcon color="#3E8635" />
         },
       }}
       actionButtons={[

--- a/packages/module/src/DetailsPageHeader/DetailsPageHeader.tsx
+++ b/packages/module/src/DetailsPageHeader/DetailsPageHeader.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { createUseStyles } from 'react-jss'
 import ActionMenu, { ActionMenuProps } from '../ActionMenu/ActionMenu';
 import ActionButton, { ActionButtonProps } from '../ActionButton/ActionButton';
+import clsx from 'clsx';
 
 export type PageHeadingLabelProps = Omit<
   LabelProps,
@@ -43,6 +44,9 @@ export interface DetailsPageHeaderProps {
 const useStyles = createUseStyles({
   detailsPageHeaderSplit: {
     alignItems: 'center',
+  },
+  detailsPageBreadcrumbs: {
+    marginTop: 'var(--pf-t--global--spacer--md)'
   }
 });
 
@@ -56,7 +60,7 @@ const DetailsPageHeader: React.FunctionComponent<DetailsPageHeaderProps> = ({
   return (
     <>
       {breadcrumbs}
-      <Split hasGutter isWrappable className={classes.detailsPageHeaderSplit}>
+      <Split hasGutter isWrappable className={clsx(classes.detailsPageHeaderSplit, { [classes.detailsPageBreadcrumbs]: breadcrumbs })}>
         <SplitItem>
           <Split hasGutter isWrappable className={`pf-v6-u-mb-sm ${classes.detailsPageHeaderSplit}`}>       
             {/* Optional icon for details page heading (before title) */}


### PR DESCRIPTION
closes #212

- added padding between breadcrumbs and heading to padding-top: 16px
- updated label to be a default label component(not compact one)

After changes:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/e9e9fd28-e28b-48db-a9c7-39f63e0aa7fa">
