### PR TITLE
fix: Update ColumnManagementModal styling

### DIFF
--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -114,7 +114,7 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
         </>
       }
       actions={[
-        <Button key="save" variant={ButtonVariant.primary} onClick={handleSave} ouiaId={`${ouiaId}-save-button`}>
+        <Button key="save" className='pf-v6-u-mr-md' variant={ButtonVariant.primary} onClick={handleSave} ouiaId={`${ouiaId}-save-button`}>
           Save
         </Button>,
         <Button key="cancel" variant={ButtonVariant.link} onClick={handleCancel} ouiaId={`${ouiaId}-cancel-button`}>


### PR DESCRIPTION
closes #201 
[RHCLOUD-34205](https://issues.redhat.com/browse/RHCLOUD-34205)

Fixed Column management modal actions gap

<img width="635" alt="image" src="https://github.com/user-attachments/assets/8d4e25a0-9ce3-4d31-bdf6-352c1c1649cb">


The font width looks correct already