### PR TITLE
Fix content header margin and component

### DIFF
--- a/packages/module/src/ContentHeader/ContentHeader.tsx
+++ b/packages/module/src/ContentHeader/ContentHeader.tsx
@@ -103,7 +103,7 @@ export const ContentHeader: React.FunctionComponent<React.PropsWithChildren<Cont
               {subtitle}
             </Text>
             {linkProps && (
-              <Button variant={ButtonVariant.link} ouiaId={`${ouiaId}-link-button`} isInline icon={linkProps.isExternal ? <ExternalLinkAltIcon /> : null} iconPosition="end" {...linkProps}>
+              <Button variant={ButtonVariant.link} component="a" ouiaId={`${ouiaId}-link-button`} isInline icon={linkProps.isExternal ? <ExternalLinkAltIcon className='pf-v5-u-ml-sm' /> : null} iconPosition="end" {...linkProps}>
                 {linkProps.label}
               </Button>
             )}


### PR DESCRIPTION
[RHCLOUD-35306](https://issues.redhat.com/browse/RHCLOUD-35306)

Fixed content header margin and component to `<a>` by default

Before:
<img width="382" alt="image-2024-09-18-20-21-21-666" src="https://github.com/user-attachments/assets/a7f0a7a4-4ac7-49f7-93bf-cd170ebdacb6">

Now:
<img width="340" alt="image" src="https://github.com/user-attachments/assets/4e0b4d81-5a04-41de-adba-46b06e17d9d8">
