### PR TITLE
fix(BulkSelect): Fix BulkSelect checked when there are no rows

### DIFF
--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -113,7 +113,7 @@ export const BulkSelect: React.FC<BulkSelectProps> = ({
                   (isDataPaginated && pagePartiallySelected) ||
                   (!isDataPaginated && selectedCount > 0 && selectedCount < totalCount)
                     ? null
-                    : pageSelected || selectedCount === totalCount
+                    : pageSelected || (selectedCount === totalCount && totalCount > 0)
                 }
                 onChange={(checked) => onSelect?.(!checked || checked === null ? noneOption : allOption)}
                 {...menuToggleCheckboxProps}


### PR DESCRIPTION
[RHCLOUD-35423](https://issues.redhat.com/browse/RHCLOUD-35423).

Fixed BulkSelect being checked when there are no rows