### PR TITLE
Hide actions dropdown when empty

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,3 +1,10 @@
+/* eslint-disable no-undef */
 import 'whatwg-fetch';
 import 'babel-polyfill';
 import '@testing-library/jest-dom';
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActionsExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActionsExample.tsx
@@ -3,15 +3,15 @@ import { ResponsiveAction } from '@patternfly/react-component-groups/dist/dynami
 import { ResponsiveActions } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveActions';
 
 export const TagCountDisabledExample: React.FunctionComponent = () => (
-  <ResponsiveActions breakpoint="lg">
+  <ResponsiveActions breakpoint="md">
     <ResponsiveAction isPersistent>
-        Persistent Action
+      Persistent Action
     </ResponsiveAction>
     <ResponsiveAction isPinned variant='secondary'>
-        Pinned Action
+      Pinned Action
     </ResponsiveAction>
     <ResponsiveAction>
-        Overflow Action
+      Overflow Action
     </ResponsiveAction>
   </ResponsiveActions>
 );


### PR DESCRIPTION
[RHCLOUD-36438](https://issues.redhat.com/browse/RHCLOUD-36438)

Fixed hiding actions dropdown when it is empty

![chrome-capture-2024-11-22 (1)](https://github.com/user-attachments/assets/b7717e62-a548-4dc7-981f-b60ca2b654ec)
