### PR TITLE
fix: fix disabling collapsed actions

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActionsExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActionsExample.tsx
@@ -13,5 +13,8 @@ export const TagCountDisabledExample: React.FunctionComponent = () => (
     <ResponsiveAction>
       Overflow Action
     </ResponsiveAction>
+    <ResponsiveAction isDisabled>
+        Disabled action
+    </ResponsiveAction>
   </ResponsiveActions>
 );

--- a/packages/module/src/ResponsiveActions/ResponsiveActions.tsx
+++ b/packages/module/src/ResponsiveActions/ResponsiveActions.tsx
@@ -78,7 +78,7 @@ export const ResponsiveActions: React.FunctionComponent<ResponsiveActionsProps> 
         );
       } else {
         dropdownItems.push(
-          <OverflowMenuDropdownItem key={key} onClick={onClick} ouiaId={`${ouiaId}-action-${key}`}>
+          <OverflowMenuDropdownItem key={key} onClick={onClick} ouiaId={`${ouiaId}-action-${key}`} isDisabled={actionProps.isDisabled}>
             {children}
           </OverflowMenuDropdownItem>
         );


### PR DESCRIPTION
Fixed disabling collapsed actions in ResponsiveActions

![Snímek obrazovky 2025-01-02 v 15 57 24](https://github.com/user-attachments/assets/518e6617-4072-4555-8338-7cdc10c65ec6)

