### PR TITLE
fix: make content header subtitle optional

### DIFF
--- a/packages/module/src/ContentHeader/ContentHeader.tsx
+++ b/packages/module/src/ContentHeader/ContentHeader.tsx
@@ -25,8 +25,8 @@ export interface PageHeaderLinkProps extends ButtonProps {
 export interface ContentHeaderProps extends React.PropsWithChildren {
   /** Title for content header */
   title: string;
-  /** Subtitle for content header */
-  subtitle: string;
+  /** Optional subtitle for content header */
+  subtitle?: string;
   /** Optional link below subtitle */
   linkProps?: PageHeaderLinkProps;
   /** Optional icon for content header (appears to the left of the content header's title with a divider) */
@@ -102,9 +102,11 @@ export const ContentHeader: React.FunctionComponent<React.PropsWithChildren<Cont
             )}
           </Split>
           <TextContent>
-            <Text component="p" ouiaId={`${ouiaId}-subtitle`}>
-              {subtitle}
-            </Text>
+            {subtitle && (
+              <Text component="p" ouiaId={`${ouiaId}-subtitle`}>
+                {subtitle}
+              </Text>
+            )}
             {linkProps && (
               <Button variant={ButtonVariant.link} component="a" ouiaId={`${ouiaId}-link-button`} isInline icon={linkProps.isExternal ? <ExternalLinkAltIcon className='pf-v5-u-ml-sm' /> : null} iconPosition="end" {...linkProps}>
                 {linkProps.label}


### PR DESCRIPTION
[RHCLOUD-37243](https://issues.redhat.com/browse/RHCLOUD-37243)

Made content header `subtitle` prop optional