### PR TITLE
fix(PageHeader) Add the option to change the classname applied to the h1

### DIFF
--- a/packages/module/src/PageHeader/PageHeader.tsx
+++ b/packages/module/src/PageHeader/PageHeader.tsx
@@ -42,6 +42,8 @@ export interface PageHeaderProps extends React.PropsWithChildren {
   ouiaId?: string | number;
   /** Child nodes */
   children?: React.ReactNode;
+  /** Optional classname that replaces the existing classname on the h1 element */
+  headingClassname?: string;
 }
 
 const useStyles = createUseStyles({
@@ -59,7 +61,8 @@ export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   breadcrumbs = null,
   actionMenu,
   ouiaId = 'PageHeader',
-  children = null
+  children = null,
+  headingClassname,
 }: PageHeaderProps) => {
   const classes = useStyles();
   const { isExternal = false, ...linkRestProps } = linkProps ?? {};
@@ -92,7 +95,7 @@ export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
                   <Split hasGutter>
                     {title && (
                       <SplitItem>
-                        <Content className="pf-v6-u-mb-sm" component="h1" ouiaId={`${ouiaId}-title`}>
+                        <Content className={headingClassname ?? 'pf-v6-u-mb-sm'} component="h1" ouiaId={`${ouiaId}-title`}>
                           {title}
                         </Content>
                       </SplitItem>


### PR DESCRIPTION
In OpenShift console, we need the ability to turn off the bottom margin on the `<h1>`.  See https://github.com/openshift/console/pull/14965#pullrequestreview-2769260754

cc: @logonoff, @nicolethoen 