### PR TITLE
feat(React19): Enable React19

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react/jsx-runtime",
     "prettier"
   ],
   "overrides": [
@@ -95,6 +96,7 @@
     "react-hooks/exhaustive-deps": "warn",
     "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }],
     "spaced-comment": "error",
-    "use-isnan": "error"
+    "use-isnan": "error",
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repo contains a set of opinionated react component groups used to standardize functionality and look and feel across products. The components are based on PatternFly with some additional functionality.
 
 ### Branches
+
 `main` - PatternFly 6 implementation
 
 `v5` - PatternFly 5 implementation
@@ -14,22 +15,27 @@ This repo contains a set of opinionated react component groups used to standardi
 ---
 
 ### Migration from [RedHatInsights/frontend-components](https://github.com/RedHatInsights/frontend-components) to [patternfly/react-component-groups](https://github.com/patternfly/react-component-groups)
+
 Please see the [migration guide](./migration.md)
 
 ---
+
 ## Contribution guide
 
 ### Before adding a new component:
+
 - make sure your use case is new/complex enough to be added to this extension
 - the component should bring a value value above and beyond existing PatternFly components
 
 ### To add a new component:
+
 1. create a folder in `src/` matching its name (for example `src/MyComponent`)
 2. to the new folder add a new `.tsx` file named after the component (for example `src/MyComponent/MyComponent.tsx`)
 3. to the same folder include an `index.ts` which will export the component as a default and then all necessary interfaces
 4. if this file structure is not met, your component won't be exposed correctly
 
 #### Example component:
+
 ```
 import * as React from 'react';
 import { Content } from '@patternfly/react-core';
@@ -49,7 +55,8 @@ const useStyles = createUseStyles({
 })
 
 // do not use the named export of your component, just a default one
-const MyComponent: React.FunctionComponent<MyComponentProps> = () => {
+import { FunctionComponent } from 'react';
+const MyComponent: FunctionComponent<MyComponentProps> = () => {
   const classes = useStyles();
 
   return (
@@ -60,23 +67,26 @@ const MyComponent: React.FunctionComponent<MyComponentProps> = () => {
 };
 
 export default MyComponent;
-``` 
+```
 
 #### Index file example:
+
 ```
 export { default } from './MyComponent';
 export * from './MyComponent';
-``` 
+```
 
 #### Component directory structure example:
+
 ```
 src
 |- MyComponent
    |- index.ts
    |- MyComponent.tsx
-``` 
+```
 
 ### Component's API rules:
+
 - prop names comply with PatternFly components naming standards (`variant`, `onClick`, `position`, etc.)
 - the API is maximally simplified and all props are provided with a description
 - it is built on top of existing PatternFly types without prop omitting
@@ -84,18 +94,22 @@ src
 - do not unnecessarily use external libraries in your component - rather, delegate the necessary logic to the component's user using the component's API
 
 #### Component API definition example:
+
 ```
+
+import { FunctionComponent } from 'react';
+
 // when possible, extend available PatternFly types
 export interface MyComponentProps extends ButtonProps {
     customLabel: Boolean
 };
 
-export const MyComponent: React.FunctionComponent<MyComponentProps> = ({ customLabel, ...props }) => ( ... );
+export const MyComponent: FunctionComponent<MyComponentProps> = ({ customLabel, ...props }) => ( ... );
 ```
-
 
 #### Markdown file example:
-```
+
+````
 ---
 section: Component groups
 subsection: My component's category
@@ -113,13 +127,14 @@ MyComponent has been created to demo contributing to this repository.
 
 ```js file="./MyComponentExample.tsx"```
 
-```
+````
 
 #### Component usage file example: (`MyComponentExample.tsx`)
-```
-import React from 'react';
 
-const MyComponentExample: React.FunctionComponent = () => (
+```
+import { FunctionComponent } from 'react';
+
+const MyComponentExample: FunctionComponent = () => (
   <MyComponent customLabel="My label">
 );
 
@@ -127,7 +142,9 @@ export default MyComponentExample;
 ```
 
 ### Sub-components:
-When adding a component for which it is advantageous to divide it into several sub-components make sure: 
+
+When adding a component for which it is advantageous to divide it into several sub-components make sure:
+
 - component and all its sub-components are located in separate files and directories straight under the `src/` folder
 - sub-components are exported and documented separately from their parent
 - parent component should provide a way to pass props to all its sub-components
@@ -135,14 +152,17 @@ When adding a component for which it is advantageous to divide it into several s
 The aim is to enable the user of our "complex" component to use either complete or take advantage of its sub-components and manage their composition independently.
 
 ### Testing:
+
 When adding/making changes to a component, always make sure your code is tested:
-- use React Testing Library for unit testing 
+
+- use React Testing Library for unit testing
 - add unit tests to a `[ComponentName].test.tsx` file to your component's directory
 - make sure all the core functionality is covered using Cypress component or E2E tests
 - add component tests to `cypress/component/[ComponentName].cy.tsx` file and E2E tests to `cypress/e2e/[ComponentName].spec.cy.ts`
 - add `ouiaId` to the component props definition with a default value of the component name (for subcomponents, let's use `ComponentName-element-specification` naming convention e.g. `ouiaId="WarningModal-confirm-button"`)
 
 ### Styling:
+
 - for styling always use JSS
 - new classNames should be named in camelCase starting with the name of a given component and following with more details clarifying its purpose/component's subsection to which the class is applied (`actionMenu`, `actionMenuDropdown`, `actionMenuDropdownToggle`, etc.)
 - do not use `pf-v6-u-XXX` classes, use CSS variables in a custom class instead (styles for the utility classes are not bundled with the standard patternfly.css - it would require the consumer to import also addons.css)
@@ -153,10 +173,12 @@ When adding/making changes to a component, always make sure your code is tested:
 - run `npm run build`
 
 ## Development
+
 - run `npm install`
 - run `npm run start` to build and start the development server
 
 ## Testing and Linting
+
 - run `npm run test` to run the unit tests
 - run `npm run cypress:run:cp` to run Cypress component tests
 - run `npm run cypress:run:e2e` to run Cypress E2E tests
@@ -165,4 +187,3 @@ When adding/making changes to a component, always make sure your code is tested:
 ## A11y testing
 
 - run `npm run build:docs` followed by `npm run serve:docs`, then run `npm run test:a11y` in a new terminal window to run our accessibility tests for the components. Once the accessibility tests have finished running you can run `npm run serve:a11y` to locally view the generated report.
-

--- a/cypress/component/Ansible.cy.tsx
+++ b/cypress/component/Ansible.cy.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
 import { Ansible } from '@patternfly/react-component-groups/dist/dynamic/Ansible';
 
 describe('Ansible', () => {
   it('renders supported Ansible', () => {
-    cy.mount(<Ansible />)
+    cy.mount(<Ansible />);
     cy.get('i').should('have.class', 'ansibleSupported-0-2-2');
   });
   it('renders unsupported Ansible', () => {
-    cy.mount(<Ansible isSupported={false}/>)
+    cy.mount(<Ansible isSupported={false} />);
     cy.get('i').should('have.class', 'ansibleUnsupported-0-2-3');
   });
 });

--- a/cypress/component/BulkSelect.cy.tsx
+++ b/cypress/component/BulkSelect.cy.tsx
@@ -1,25 +1,31 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import BulkSelect, { BulkSelectProps, BulkSelectValue } from '../../packages/module/dist/dynamic/BulkSelect';
 
 interface DataItem {
-  name: string
-};
+  name: string;
+}
 
-const BulkSelectTestComponent = ({ canSelectAll, isDataPaginated }: Omit<BulkSelectProps, 'onSelect' | 'selectedCount' >) => {
+const BulkSelectTestComponent = ({
+  canSelectAll,
+  isDataPaginated
+}: Omit<BulkSelectProps, 'onSelect' | 'selectedCount'>) => {
   const [ selected, setSelected ] = useState<DataItem[]>([]);
 
   const allData = [ { name: '1' }, { name: '2' }, { name: '3' }, { name: '4' }, { name: '5' }, { name: '6' } ];
   const pageData = [ { name: '1' }, { name: '2' }, { name: '3' }, { name: '4' }, { name: '5' } ];
   const pageDataNames = pageData.map((item) => item.name);
-  const pageSelected = pageDataNames.every(item => selected.find(selectedItem => selectedItem.name === item));
+  const pageSelected = pageDataNames.every((item) => selected.find((selectedItem) => selectedItem.name === item));
 
   const handleBulkSelect = (value: BulkSelectValue) => {
     if (value === BulkSelectValue.page) {
       const updatedSelection = [ ...selected ];
-      pageData.forEach(item => !updatedSelection.some(selectedItem => selectedItem.name === item.name) && updatedSelection.push(item));
+      pageData.forEach(
+        (item) =>
+          !updatedSelection.some((selectedItem) => selectedItem.name === item.name) && updatedSelection.push(item)
+      );
       setSelected(updatedSelection);
     }
-    value === BulkSelectValue.nonePage && setSelected(selected.filter(item => !pageDataNames.includes(item.name)))
+    value === BulkSelectValue.nonePage && setSelected(selected.filter((item) => !pageDataNames.includes(item.name)));
     value === BulkSelectValue.none && setSelected([]);
     value === BulkSelectValue.all && setSelected(allData);
   };
@@ -32,7 +38,9 @@ const BulkSelectTestComponent = ({ canSelectAll, isDataPaginated }: Omit<BulkSel
       totalCount={allData.length}
       selectedCount={selected.length}
       pageSelected={pageSelected}
-      pagePartiallySelected={pageDataNames.some(item => selected.find(selectedItem => selectedItem.name === item)) && !pageSelected}
+      pagePartiallySelected={
+        pageDataNames.some((item) => selected.find((selectedItem) => selectedItem.name === item)) && !pageSelected
+      }
       onSelect={handleBulkSelect}
     />
   );
@@ -40,60 +48,54 @@ const BulkSelectTestComponent = ({ canSelectAll, isDataPaginated }: Omit<BulkSel
 
 describe('BulkSelect', () => {
   it('renders the bulk select without all', () => {
-    cy.mount(
-      <BulkSelectTestComponent />
-    );
+    cy.mount(<BulkSelectTestComponent />);
     cy.get('[data-ouia-component-id="BulkSelect-checkbox"]').should('exist');
     cy.get('[data-ouia-component-id="BulkSelect-toggle"]').click();
     cy.get('[data-ouia-component-id="BulkSelect-select-all"]').should('not.exist');
     cy.get('[data-ouia-component-id="BulkSelect-select-page"]').should('exist');
     cy.get('[data-ouia-component-id="BulkSelect-select-none"]').should('exist');
-  
+
     cy.contains('0 selected').should('not.exist');
   });
 
   it('renders the bulk select with all and without page', () => {
-    cy.mount(
-      <BulkSelectTestComponent canSelectAll isDataPaginated={false} />
-    );
+    cy.mount(<BulkSelectTestComponent canSelectAll isDataPaginated={false} />);
     cy.get('[data-ouia-component-id="BulkSelect-checkbox"]').should('exist');
     cy.get('[data-ouia-component-id="BulkSelect-toggle"]').click();
     cy.get('[data-ouia-component-id="BulkSelect-select-all"]').should('exist');
     cy.get('[data-ouia-component-id="BulkSelect-select-page"]').should('not.exist');
     cy.get('[data-ouia-component-id="BulkSelect-select-none"]').should('exist');
-  
+
     cy.contains('0 selected').should('not.exist');
   });
-  
+
   it('renders the bulk select with data', () => {
-    cy.mount(
-      <BulkSelectTestComponent canSelectAll />
-    );
-  
+    cy.mount(<BulkSelectTestComponent canSelectAll />);
+
     // Initial state
     cy.get('input[type="checkbox"]').each(($checkbox) => {
       cy.wrap($checkbox).should('not.be.checked');
     });
-  
+
     // Checkbox select
     cy.get('[data-ouia-component-id="BulkSelect-checkbox"]').first().click();
     cy.get('input[type="checkbox"]').should('be.checked');
     cy.contains('5 selected').should('exist');
-  
+
     // Select none
     cy.get('[data-ouia-component-id="BulkSelect-toggle"]').first().click({ force: true });
     cy.get('[data-ouia-component-id="BulkSelect-select-none"]').first().click();
     cy.get('input[type="checkbox"]').should('not.be.checked');
-  
+
     // Select all
     cy.get('[data-ouia-component-id="BulkSelect-toggle"]').first().click({ force: true });
     cy.get('[data-ouia-component-id="BulkSelect-select-all"]').first().click();
     cy.contains('6 selected').should('exist');
-  
+
     // Checkbox deselect
     cy.get('[data-ouia-component-id="BulkSelect-checkbox"]').first().click({ force: true });
     cy.contains('1 selected').should('exist');
-  
+
     // Select page
     cy.get('[data-ouia-component-id="BulkSelect-toggle"]').first().click({ force: true });
     cy.get('[data-ouia-component-id="BulkSelect-select-page"]').first().click();

--- a/cypress/component/CloseButton.cy.tsx
+++ b/cypress/component/CloseButton.cy.tsx
@@ -1,16 +1,23 @@
-import React from 'react';
 import CloseButton from '../../packages/module/dist/dynamic/CloseButton';
 
 describe('CloseButton', () => {
   /* eslint-disable no-console */
   it('renders the Close button', () => {
-    cy.mount(<CloseButton dataTestID="close-button-example" onClick={()=>{console.log('Close button clicked')}} style={{ float: 'none' }}/>)
+    cy.mount(
+      <CloseButton
+        dataTestID="close-button-example"
+        onClick={() => {
+          console.log('Close button clicked');
+        }}
+        style={{ float: 'none' }}
+      />
+    );
     cy.get('[data-test-id="close-button-example"]').should('exist');
   });
   it('should call callback on click', () => {
     const onClickSpy = cy.spy().as('onClickSpy');
-    cy.mount(<CloseButton dataTestID="close-button-example" onClick={onClickSpy}/>);
+    cy.mount(<CloseButton dataTestID="close-button-example" onClick={onClickSpy} />);
     cy.get('[data-test-id="close-button-example"]').click();
     cy.get('@onClickSpy').should('have.been.called');
   });
-})
+});

--- a/cypress/component/ErrorBoundary.cy.tsx
+++ b/cypress/component/ErrorBoundary.cy.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
 import ErrorBoundary from '../../packages/module/dist/dynamic/ErrorBoundary';
 
 describe('ErrorBoundary', () => {
   it('renders the ErrorBoundary ', () => {
-    cy.mount(<ErrorBoundary headerTitle="My app header" errorTitle="Something wrong happened"><div data-ouia-component-id="test">Test</div></ErrorBoundary>)
+    cy.mount(
+      <ErrorBoundary headerTitle="My app header" errorTitle="Something wrong happened">
+        <div data-ouia-component-id="test">Test</div>
+      </ErrorBoundary>
+    );
     cy.get('[data-ouia-component-id="test"]').should('have.text', 'Test');
   });
 
@@ -11,11 +14,13 @@ describe('ErrorBoundary', () => {
     const Surprise = () => {
       throw new Error('but a welcome one');
     };
-    cy.mount(<ErrorBoundary headerTitle="My app header" errorTitle="Something wrong happened">
-      <Surprise />
-    </ErrorBoundary>)
+    cy.mount(
+      <ErrorBoundary headerTitle="My app header" errorTitle="Something wrong happened">
+        <Surprise />
+      </ErrorBoundary>
+    );
 
     cy.get('[data-ouia-component-id="ErrorBoundary-toggle"').click();
     cy.get('[class="pf-v5-c-expandable-section__content"]').should('contain.text', 'Error: but a welcome one');
-  })
-})
+  });
+});

--- a/cypress/component/ErrorState.cy.tsx
+++ b/cypress/component/ErrorState.cy.tsx
@@ -1,21 +1,28 @@
-import React from 'react';
 import ErrorState from '../../packages/module/dist/dynamic/ErrorState';
-import { ActionButton } from '../../packages/module/dist/dynamic/ActionButton'
+import { ActionButton } from '../../packages/module/dist/dynamic/ActionButton';
 
 describe('ErrorState', () => {
   it('renders the Close button', () => {
-    cy.mount(<ErrorState titleText='Sample error title' bodyText='Sample error description' />);
+    cy.mount(<ErrorState titleText="Sample error title" bodyText="Sample error description" />);
     cy.get('[data-ouia-component-id="ErrorState"]').contains('Sample error title');
     cy.get('[data-ouia-component-id="ErrorState-body"]').should('have.text', 'Sample error description');
   });
 
   it('render with a custom footer', () => {
     const onClickSpy = cy.spy().as('onClickSpy');
-    cy.mount(<ErrorState titleText='Sample error title' bodyText='Sample error description' customFooter={<ActionButton variant="secondary" onClick={onClickSpy}>
-    Custom action
-    </ActionButton>}/>);
-    cy.get('button').should('have.text', "Custom action");
+    cy.mount(
+      <ErrorState
+        titleText="Sample error title"
+        bodyText="Sample error description"
+        customFooter={
+          <ActionButton variant="secondary" onClick={onClickSpy}>
+            Custom action
+          </ActionButton>
+        }
+      />
+    );
+    cy.get('button').should('have.text', 'Custom action');
     cy.get('button').click();
     cy.get('@onClickSpy').should('have.been.called');
-  })
-})
+  });
+});

--- a/cypress/component/LogSnippet.cy.tsx
+++ b/cypress/component/LogSnippet.cy.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import LogSnippet from '../../packages/module/dist/dynamic/LogSnippet';
 
 describe('LogSnippet', () => {
   it('renders LogSnippet', () => {
-    cy.mount(<LogSnippet logSnippet='test test code' message='A test message'/>)
+    cy.mount(<LogSnippet logSnippet="test test code" message="A test message" />);
     cy.get('[data-ouia-component-id="LogSnippet-message"]').contains('A test message');
     cy.get('[data-ouia-component-id="LogSnippet-code-content"]').contains('test code');
   });

--- a/cypress/component/Maintenance.cy.tsx
+++ b/cypress/component/Maintenance.cy.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
 import Maintenance from '@patternfly/react-component-groups/dist/dynamic/Maintenance';
 
 describe('Maintenance', () => {
   it('renders Maintenance', () => {
-    cy.mount(<Maintenance />)
+    cy.mount(<Maintenance />);
     cy.get('[data-ouia-component-id="Maintenance"]').should('exist');
     cy.get('[data-ouia-component-id="Maintenance"]').contains('Maintenance in progress');
-    cy.get('[data-ouia-component-id="Maintenance-body"]').contains('We are currently undergoing scheduled maintenance and will be unavailable from 6am to 8am UTC. For more information please visit status.redhat.com.');
+    cy.get('[data-ouia-component-id="Maintenance-body"]').contains(
+      'We are currently undergoing scheduled maintenance and will be unavailable from 6am to 8am UTC. For more information please visit status.redhat.com.'
+    );
   });
 });

--- a/cypress/component/MissingPage.cy.tsx
+++ b/cypress/component/MissingPage.cy.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
 import MissingPage from '@patternfly/react-component-groups/dist/dynamic/MissingPage';
 
 describe('MissingPage', () => {
   it('renders MissingPage', () => {
-    cy.mount(<MissingPage />)
-    cy.get('[data-ouia-component-id="MissingPage"]').should('exist')
+    cy.mount(<MissingPage />);
+    cy.get('[data-ouia-component-id="MissingPage"]').should('exist');
     cy.get('[data-ouia-component-id="MissingPage"]').contains('We lost that page');
-    cy.get('[data-ouia-component-id="MissingPage-body"]').contains("Let's find you a new one. Try a new search or return home.");
+    cy.get('[data-ouia-component-id="MissingPage-body"]').contains(
+      "Let's find you a new one. Try a new search or return home."
+    );
     cy.get('[data-ouia-component-id="MissingPage-home-button"]').contains('Return to homepage');
   });
-})
+});

--- a/cypress/component/MultiContentCard.cy.tsx
+++ b/cypress/component/MultiContentCard.cy.tsx
@@ -1,6 +1,17 @@
-import React from 'react';
-import MultiContentCard from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
-import { Button, Card, CardHeader, CardBody, Content, ContentVariants, Icon, List, ListItem, CardFooter } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+import MultiContentCard from '@patternfly/react-component-groups/dist/dynamic/MultiContentCard';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  Content,
+  ContentVariants,
+  Icon,
+  List,
+  ListItem,
+  CardFooter
+} from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, LockIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
@@ -8,16 +19,16 @@ import clsx from 'clsx';
 const useStyles = createUseStyles({
   action: {
     color: 'var(--pf-t--global--text--color--brand--default)',
-    fontSize: 'var(-pf-t--global--font--size--sm)',
-  }, 
-  bulletPoints: {
-    color: 'var(--pf-t--global--color--brand--default)',
+    fontSize: 'var(-pf-t--global--font--size--sm)'
   },
+  bulletPoints: {
+    color: 'var(--pf-t--global--color--brand--default)'
+  }
 });
 
-export const MultiContentCardExample: React.FunctionComponent = () => {
+export const MultiContentCardExample: FunctionComponent = () => {
   const classes = useStyles();
-  
+
   const cards = [
     <Card isFullHeight isPlain key="card-1">
       <CardHeader>
@@ -28,22 +39,29 @@ export const MultiContentCardExample: React.FunctionComponent = () => {
           <Icon size="md" className="pf-v6-u-pl-sm pf-v6-u-pr-md">
             <CogIcon />
           </Icon>
-            Configure application
+          Configure application
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <List className={clsx(classes.bulletPoints, 'pf-v6-u-font-size-sm', 'pf-v6-u-ml-0')}>
           <ListItem>
-            <Button variant="link" isInline>First link</Button>
+            <Button variant="link" isInline>
+              First link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Second link</Button>
+            <Button variant="link" isInline>
+              Second link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Another link</Button>
+            <Button variant="link" isInline>
+              Another link
+            </Button>
           </ListItem>
         </List>
       </CardFooter>
@@ -54,19 +72,26 @@ export const MultiContentCardExample: React.FunctionComponent = () => {
           <Icon size="md" className="pf-v6-u-pl-sm pf-v6-u-pr-md">
             <LockIcon />
           </Icon>
-            Configure access
+          Configure access
         </Content>
         <Content>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon />
-          </Icon>} variant="link" isInline>
-              Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
@@ -80,27 +105,33 @@ export const MultiContentCardExample: React.FunctionComponent = () => {
           <Icon size="md" className="pf-v6-u-pl-sm pf-v6-u-pr-md">
             <BellIcon />
           </Icon>
-            Configure notifications
+          Configure notifications
         </Content>
         <Content>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon />
-          </Icon>} variant="link" isInline>
-              Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
     </Card>
   ];
 
-  return (<MultiContentCard cards={cards} />);
-}
+  return <MultiContentCard cards={cards} />;
+};
 
 describe('MultiContentCard', () => {
   it('renders MultiContentCard', () => {

--- a/cypress/component/NotAuthorized.cy.tsx
+++ b/cypress/component/NotAuthorized.cy.tsx
@@ -1,31 +1,30 @@
-import React from 'react';
 import { Button } from '@patternfly/react-core';
 import NotAuthorized from '../../packages/module/dist/dynamic/NotAuthorized';
 
 describe('NotAuthorized', () => {
   it('renders basic NotAuthorized', () => {
-    cy.mount(<NotAuthorized 
-      bodyText="Test text" 
-      serviceName="Test bundle"
-    />);
+    cy.mount(<NotAuthorized bodyText="Test text" serviceName="Test bundle" />);
     cy.get('[data-ouia-component-id="NotAuthorized"]').contains('You do not have access to Test bundle');
     cy.get('[data-ouia-component-id="NotAuthorized-body"]').contains('Test text');
   });
 
   it('renders NotAuthorized with custom action buttons', () => {
     const onClickSpy = cy.spy().as('onClickSpy');
-    const primaryAction = 
-    <Button key="1" onClick={onClickSpy} ouiaId="test-button">
-      Custom primary action
-    </Button>;
-    const customNotAuthorized = <NotAuthorized 
-      primaryAction={primaryAction}
-      bodyText="Test text" 
-      serviceName="Demo bundle"
-      prevPageButtonText="Go to previous page"
-    />
+    const primaryAction = (
+      <Button key="1" onClick={onClickSpy} ouiaId="test-button">
+        Custom primary action
+      </Button>
+    );
+    const customNotAuthorized = (
+      <NotAuthorized
+        primaryAction={primaryAction}
+        bodyText="Test text"
+        serviceName="Demo bundle"
+        prevPageButtonText="Go to previous page"
+      />
+    );
     cy.mount(customNotAuthorized);
-    const customButton = cy.get('[data-ouia-component-id="test-button"]')
+    const customButton = cy.get('[data-ouia-component-id="test-button"]');
     customButton.should('exist');
     customButton.should('have.text', 'Custom primary action');
     customButton.click();

--- a/cypress/component/PageHeader.cy.tsx
+++ b/cypress/component/PageHeader.cy.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
 import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader';
 
 describe('PageHeader', () => {
   it('should render PageHeader title and subtitle', () => {
-    cy.mount(<PageHeader title='My title' subtitle='This is a subtitle for your page header' />);
-    cy.get('title').should('exist')
-    cy.get('[data-ouia-component-id="PageHeader-title"]').should('have.text', 'My title')
-    cy.get('[data-ouia-component-id="PageHeader-subtitle"]').should('have.text', 'This is a subtitle for your page header')
-  })
+    cy.mount(<PageHeader title="My title" subtitle="This is a subtitle for your page header" />);
+    cy.get('title').should('exist');
+    cy.get('[data-ouia-component-id="PageHeader-title"]').should('have.text', 'My title');
+    cy.get('[data-ouia-component-id="PageHeader-subtitle"]').should(
+      'have.text',
+      'This is a subtitle for your page header'
+    );
+  });
 });

--- a/cypress/component/ResponsiveActions.cy.tsx
+++ b/cypress/component/ResponsiveActions.cy.tsx
@@ -1,24 +1,19 @@
-import React from 'react';
 import { ResponsiveActions } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveActions';
 import { ResponsiveAction } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveAction';
 
 describe('ResponsiveActions', () => {
   beforeEach(() => {
     cy.viewport(1280, 2000);
-  })
+  });
 
   it('renders persistent, pinned, and overflow actions', () => {
     cy.mount(
       <ResponsiveActions breakpoint="lg">
-        <ResponsiveAction isPersistent>
-          Persistent action
-        </ResponsiveAction>
-        <ResponsiveAction isPinned variant='secondary'>
+        <ResponsiveAction isPersistent>Persistent action</ResponsiveAction>
+        <ResponsiveAction isPinned variant="secondary">
           Pinned action
         </ResponsiveAction>
-        <ResponsiveAction>
-          Overflow action
-        </ResponsiveAction>
+        <ResponsiveAction>Overflow action</ResponsiveAction>
       </ResponsiveActions>
     );
 
@@ -29,7 +24,7 @@ describe('ResponsiveActions', () => {
     cy.get('[data-ouia-component-id="ResponsiveActions-menu-dropdown-toggle"]').click();
     cy.get('[data-ouia-component-id="ResponsiveActions-action-2"]').should('be.visible');
   });
-  
+
   it('handles click events on actions', () => {
     const onClickSpy = cy.spy().as('actionClickSpy');
 
@@ -38,12 +33,10 @@ describe('ResponsiveActions', () => {
         <ResponsiveAction isPersistent onClick={onClickSpy}>
           Persistent action
         </ResponsiveAction>
-        <ResponsiveAction isPinned variant='secondary' onClick={onClickSpy}>
+        <ResponsiveAction isPinned variant="secondary" onClick={onClickSpy}>
           Pinned action
         </ResponsiveAction>
-        <ResponsiveAction onClick={onClickSpy}>
-          Overflow action
-        </ResponsiveAction>
+        <ResponsiveAction onClick={onClickSpy}>Overflow action</ResponsiveAction>
       </ResponsiveActions>
     );
 
@@ -61,9 +54,7 @@ describe('ResponsiveActions', () => {
   it('renders no persistent or pinned actions without flags', () => {
     cy.mount(
       <ResponsiveActions breakpoint="lg">
-        <ResponsiveAction>
-          Overflow action
-        </ResponsiveAction>
+        <ResponsiveAction>Overflow action</ResponsiveAction>
       </ResponsiveActions>
     );
 

--- a/cypress/component/ServiceCard.cy.tsx
+++ b/cypress/component/ServiceCard.cy.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ServiceCard from '../../packages/module/dist/dynamic/ServiceCard';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 
@@ -6,43 +5,43 @@ describe('ServiceCard', () => {
   it('renders ServiceCard', () => {
     cy.mount(
       <ServiceCard
-        title='Example'
-        subtitle='A basic example'
-        description='This is a basic ServiceCard Example'
+        title="Example"
+        subtitle="A basic example"
+        description="This is a basic ServiceCard Example"
         icon={<img src="/" alt="page-header-icon" />}
-        helperText='Here is helper text'
-        ouiaId='Example'
-      />)
+        helperText="Here is helper text"
+        ouiaId="Example"
+      />
+    );
     cy.get('[data-ouia-component-id="Example-card"]').should('exist');
   });
   it('renders custom footer', () => {
     cy.mount(
       <ServiceCard
-        title='Example'
-        subtitle='A basic example'
-        description='This is a basic ServiceCard Example'
+        title="Example"
+        subtitle="A basic example"
+        description="This is a basic ServiceCard Example"
         icon={<img src="/" alt="page-header-icon" />}
-        helperText='Here is helper text'
-        ouiaId='Example'
-        footer={<>
-          <Button
-            variant={ButtonVariant.secondary}
-            isInline
-            className='pf-v5-u-pr-md'
-            component="a"
-            href='www.google.com'>
-            Launch
-          </Button>
-          <Button
-            variant={ButtonVariant.link}
-            component="a"
-            isInline
-            href='www.google.com'
-          >
-            Learn More
-          </Button></>
+        helperText="Here is helper text"
+        ouiaId="Example"
+        footer={
+          <>
+            <Button
+              variant={ButtonVariant.secondary}
+              isInline
+              className="pf-v5-u-pr-md"
+              component="a"
+              href="www.google.com"
+            >
+              Launch
+            </Button>
+            <Button variant={ButtonVariant.link} component="a" isInline href="www.google.com">
+              Learn More
+            </Button>
+          </>
         }
-      />)
+      />
+    );
     cy.get('[data-ouia-component-id="Example-footer"]').should('exist');
-  })
+  });
 });

--- a/cypress/component/Severity.cy.tsx
+++ b/cypress/component/Severity.cy.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import Severity, { SeverityType } from '../../packages/module/dist/dynamic/Severity';
 
-const severities = [    
+const severities = [
   { type: SeverityType.critical, label: 'Critical severity', ouiaId: 'Severity-critical' },
   { type: SeverityType.important, label: 'Important severity', ouiaId: 'Severity-important' },
   { type: SeverityType.moderate, label: 'Moderate severity', ouiaId: 'Severity-moderate' },
@@ -19,7 +18,7 @@ describe('Severity', () => {
       cy.get('span').contains(label);
     });
   });
-  
+
   it('hides label when labelHidden is true', () => {
     cy.mount(<Severity severity={SeverityType.important} label="Important severity" labelHidden />);
     cy.contains('Important severity').should('not.exist');

--- a/cypress/component/ShortcutGrid.cy.tsx
+++ b/cypress/component/ShortcutGrid.cy.tsx
@@ -1,22 +1,21 @@
-import React from 'react';
 import ShortcutGrid from '../../packages/module/dist/dynamic/ShortcutGrid';
 
-const shortcuts = [ 
-  { description: 'Open new tab', keys: [ 'cmd', 'shift', 't' ] }, 
+const shortcuts = [
+  { description: 'Open new tab', keys: [ 'cmd', 'shift', 't' ] },
   { description: 'Open new page', keys: [ 'opt', 'n' ] },
-  { description: 'Move object', keys: [ 'ctrl' ], drag: true },  
+  { description: 'Move object', keys: [ 'ctrl' ], drag: true }
 ];
 
 describe('ShortcutGrid', () => {
   it('renders ShortcutGrid', () => {
-    const shortCutGridExample = <ShortcutGrid 
-      shortcuts={shortcuts}
-    />
+    const shortCutGridExample = <ShortcutGrid shortcuts={shortcuts} />;
     cy.mount(shortCutGridExample);
     cy.get('[data-ouia-component-id="ShortcutGrid"]').should('exist');
     shortcuts.forEach((shortcut, index) => {
-      cy.get(`[data-ouia-component-id="ShortcutGrid-item-description-${index}"]`)
-        .should('have.text', shortcut.description);
+      cy.get(`[data-ouia-component-id="ShortcutGrid-item-description-${index}"]`).should(
+        'have.text',
+        shortcut.description
+      );
     });
   });
-})
+});

--- a/cypress/component/SkeletonTable.cy.tsx
+++ b/cypress/component/SkeletonTable.cy.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { RowSelectVariant } from '@patternfly/react-table';
 import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/SkeletonTable';
 
@@ -15,7 +14,7 @@ describe('SkeletonTable', () => {
     cy.get('table thead tr th').eq(1).should('have.text', 'Second');
   });
 
-  it ('can be used without passing columns', () => {
+  it('can be used without passing columns', () => {
     const SkeletonTableExample = <SkeletonTable rowsCount={10} columnsCount={2} />;
     cy.mount(SkeletonTableExample);
     cy.get('table').should('exist');
@@ -43,7 +42,9 @@ describe('SkeletonTable', () => {
   });
 
   it('can be passed a selectVariant to render radio buttons', () => {
-    const SkeletonTableExample = <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} isSelectable selectVariant={RowSelectVariant.radio} />;
+    const SkeletonTableExample = (
+      <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} isSelectable selectVariant={RowSelectVariant.radio} />
+    );
     cy.mount(SkeletonTableExample);
     cy.get('table').should('exist');
     cy.get('table thead tr th').eq(0).should('have.text', 'Data selection table header cell');
@@ -56,7 +57,7 @@ describe('SkeletonTable', () => {
     const SkeletonTableExample = (
       <SkeletonTable
         rows={10}
-        columns={[ 
+        columns={[
           { cell: 'first', props: { sort: { columnIndex: 0, sortBy: { index: 0, direction: 'asc' } } } },
           { cell: 'second' },
           { cell: 'third' }
@@ -73,5 +74,5 @@ describe('SkeletonTable', () => {
       'd',
       'M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z' // ascending
     );
-  })
+  });
 });

--- a/cypress/component/SkeletonTableBody.cy.tsx
+++ b/cypress/component/SkeletonTableBody.cy.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { RowSelectVariant } from '@patternfly/react-table';
 import SkeletonTableBody from '@patternfly/react-component-groups/dist/dynamic/SkeletonTableBody';
 

--- a/cypress/component/SkeletonTableHead.cy.tsx
+++ b/cypress/component/SkeletonTableHead.cy.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Table } from '@patternfly/react-table';
 import { SkeletonTableHead } from '@patternfly/react-component-groups/dist/dynamic/SkeletonTableHead';
 

--- a/cypress/component/Status.cy.tsx
+++ b/cypress/component/Status.cy.tsx
@@ -1,42 +1,59 @@
-import * as React from 'react';
 import { ExclamationTriangleIcon, CheckCircleIcon, BanIcon } from '@patternfly/react-icons';
 import { Button, ButtonVariant, ButtonSize } from '@patternfly/react-core';
 import { IconStatus, Status, StatusVariant } from '../../packages/module/dist/dynamic/Status';
 
 describe('Status', () => {
-  
   it('should render with label and icon', () => {
-    cy.mount(<Status status={IconStatus.warning} label='Warning' icon={<ExclamationTriangleIcon/>} />);
+    cy.mount(<Status status={IconStatus.warning} label="Warning" icon={<ExclamationTriangleIcon />} />);
     cy.get(`[data-ouia-component-id="Status-label"]`).should('be.visible');
     cy.get(`[data-ouia-component-id="Status-icon"]`).should('be.visible');
   });
 
   it('should render with iconOnly', () => {
-    cy.mount(<Status iconOnly status={IconStatus.warning} label='Warning' iconTitle='1 security issue found' icon={<ExclamationTriangleIcon/>} />);
+    cy.mount(
+      <Status
+        iconOnly
+        status={IconStatus.warning}
+        label="Warning"
+        iconTitle="1 security issue found"
+        icon={<ExclamationTriangleIcon />}
+      />
+    );
     cy.get(`[data-ouia-component-id="Status-label"]`).should('not.exist');
     cy.get(`[data-ouia-component-id="Status-icon"]`).should('be.visible');
   });
 
   it('should render link variant and handle click', () => {
     const handleClick = cy.stub().as('handleClick');
-    cy.mount(<Status status={IconStatus.success} variant={StatusVariant.link} label='Ready' onClick={handleClick} icon={<CheckCircleIcon/>} />);
+    cy.mount(
+      <Status
+        status={IconStatus.success}
+        variant={StatusVariant.link}
+        label="Ready"
+        onClick={handleClick}
+        icon={<CheckCircleIcon />}
+      />
+    );
     cy.get(`[data-ouia-component-id="Status-label"]`).should('be.visible');
     cy.get(`[data-ouia-component-id="Status-icon"]`).should('be.visible');
     cy.get(`[data-ouia-component-id="Status-link-icon"]`).click();
     cy.get('@handleClick').should('have.been.calledOnce');
-
   });
 
   it('should render popover variant and handle open/close', () => {
     cy.mount(
       <Status
         status={IconStatus.danger}
-        variant={StatusVariant.popover} 
-        label='Not Ready' 
-        icon={<BanIcon/>}
-        popoverProps={{ 
-          bodyContent: 'Example state description', 
-          footerContent: <Button size={ButtonSize.sm} variant={ButtonVariant.link} isInline>Action</Button> 
+        variant={StatusVariant.popover}
+        label="Not Ready"
+        icon={<BanIcon />}
+        popoverProps={{
+          bodyContent: 'Example state description',
+          footerContent: (
+            <Button size={ButtonSize.sm} variant={ButtonVariant.link} isInline>
+              Action
+            </Button>
+          )
         }}
       />
     );
@@ -47,14 +64,19 @@ describe('Status', () => {
     cy.get('[role="dialog"]').should('be.visible');
     cy.get('body').click(0, 0);
     cy.get('[role="dialog"]').should('not.exist');
-
   });
 
   it('should render with description', () => {
-    cy.mount(<Status status={IconStatus.warning} label='Warning' description='1 issue found' icon={<ExclamationTriangleIcon/>} />);
+    cy.mount(
+      <Status
+        status={IconStatus.warning}
+        label="Warning"
+        description="1 issue found"
+        icon={<ExclamationTriangleIcon />}
+      />
+    );
     cy.get(`[data-ouia-component-id="Status-label"]`).should('be.visible');
     cy.get(`[data-ouia-component-id="Status-icon"]`).should('be.visible');
     cy.get(`[data-ouia-component-id="Status-description"]`).should('be.visible');
   });
-
 });

--- a/cypress/component/TagCount.cy.tsx
+++ b/cypress/component/TagCount.cy.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
 import TagCount from '../../packages/module/dist/dynamic/TagCount';
 
 describe('TagCount', () => {
   it('renders TagCount', () => {
-    cy.mount(<TagCount count={50} />)
+    cy.mount(<TagCount count={50} />);
     cy.get('button[data-ouia-component-id="TagCount"]').should('exist');
     cy.get('[data-ouia-component-id="TagCount-text"]').contains('50');
   });
 
   it('render disabled', () => {
-    cy.mount(<TagCount disabled={true} />)
+    cy.mount(<TagCount disabled={true} />);
     cy.get('button[data-ouia-component-id="TagCount"]').should('be.disabled');
   });
 });

--- a/cypress/component/UnavailableContent.cy.tsx
+++ b/cypress/component/UnavailableContent.cy.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
 import UnavailableContent from '../../packages/module/dist/dynamic/UnavailableContent';
 
 describe('UnavailableContent', () => {
   it('renders UnavailableContent', () => {
-    cy.mount(<UnavailableContent />)
+    cy.mount(<UnavailableContent />);
     cy.get('[data-ouia-component-id="UnavailableContent"]').should('exist');
     cy.get('[data-ouia-component-id="UnavailableContent"]').contains('This page is temporarily unavailable');
-    cy.get('[data-ouia-component-id="UnavailableContent-body"]').contains('Try refreshing the page. If the problem persists, contact your organization administrator or visit our status page for known outages.');
+    cy.get('[data-ouia-component-id="UnavailableContent-body"]').contains(
+      'Try refreshing the page. If the problem persists, contact your organization administrator or visit our status page for known outages.'
+    );
   });
 });

--- a/cypress/component/WarningModal.cy.tsx
+++ b/cypress/component/WarningModal.cy.tsx
@@ -1,58 +1,67 @@
-import React from 'react';
+import { FunctionComponent, useState } from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import WarningModal from '../../packages/module/dist/dynamic/WarningModal';
 
-const BasicModal: React.FunctionComponent = () => {
-  const [ isOpen, setIsOpen ] = React.useState(false);
-  return <>
-    <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-    <WarningModal
-      isOpen={isOpen}
-      title='Unsaved changes'
-      confirmButtonLabel='Yes'
-      cancelButtonLabel='No'
-      onClose={() => setIsOpen(false)}
-      onConfirm={() => setIsOpen(false)}>
-      Your page contains unsaved changes. Do you want to leave?
-    </WarningModal>
-  </>
+const BasicModal: FunctionComponent = () => {
+  const [ isOpen, setIsOpen ] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+      <WarningModal
+        isOpen={isOpen}
+        title="Unsaved changes"
+        confirmButtonLabel="Yes"
+        cancelButtonLabel="No"
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+      >
+        Your page contains unsaved changes. Do you want to leave?
+      </WarningModal>
+    </>
+  );
 };
 
-const CheckboxModal: React.FunctionComponent = () => {
-  const [ isOpen, setIsOpen ] = React.useState(false);
-  return <>
-    <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-    <WarningModal
-      isOpen={isOpen}
-      title='Unsaved changes'
-      confirmButtonLabel='Yes'
-      cancelButtonLabel='No'
-      onClose={() => setIsOpen(false)}
-      onConfirm={() => setIsOpen(false)}
-      withCheckbox
-      checkboxLabel='Are you sure?'
-      confirmButtonVariant={ButtonVariant.danger}>
-      Your page contains unsaved changes. Do you want to leave?
-    </WarningModal>
-  </>
+const CheckboxModal: FunctionComponent = () => {
+  const [ isOpen, setIsOpen ] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+      <WarningModal
+        isOpen={isOpen}
+        title="Unsaved changes"
+        confirmButtonLabel="Yes"
+        cancelButtonLabel="No"
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+        withCheckbox
+        checkboxLabel="Are you sure?"
+        confirmButtonVariant={ButtonVariant.danger}
+      >
+        Your page contains unsaved changes. Do you want to leave?
+      </WarningModal>
+    </>
+  );
 };
 
-const TextConfirmationModal: React.FunctionComponent = () => {
-  const [ isOpen, setIsOpen ] = React.useState(false);
-  return <>
-    <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-    <WarningModal
-      isOpen={isOpen}
-      title='Delete item?'
-      confirmButtonLabel='Yes'
-      cancelButtonLabel='No'
-      onClose={() => setIsOpen(false)}
-      onConfirm={() => setIsOpen(false)}
-      textConfirmation={{ type: 'text', isRequired: true }}
-      deleteName='Item1'>
-      The item will be deleted.
-    </WarningModal>
-  </>
+const TextConfirmationModal: FunctionComponent = () => {
+  const [ isOpen, setIsOpen ] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+      <WarningModal
+        isOpen={isOpen}
+        title="Delete item?"
+        confirmButtonLabel="Yes"
+        cancelButtonLabel="No"
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+        textConfirmation={{ type: 'text', isRequired: true }}
+        deleteName="Item1"
+      >
+        The item will be deleted.
+      </WarningModal>
+    </>
+  );
 };
 
 describe('WarningModal', () => {
@@ -61,7 +70,9 @@ describe('WarningModal', () => {
     cy.get('button').click();
     cy.get('[data-ouia-component-id="WarningModal"]').should('exist');
     cy.get('[data-ouia-component-id="WarningModal"]').contains('Unsaved changes');
-    cy.get('[data-ouia-component-id="WarningModal"]').contains('Your page contains unsaved changes. Do you want to leave?');
+    cy.get('[data-ouia-component-id="WarningModal"]').contains(
+      'Your page contains unsaved changes. Do you want to leave?'
+    );
   });
 
   it('confirm button should be disabled if checkbox is not checked', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,4 +1,4 @@
-/// <reference types="cypress" />
+// / <reference types="cypress" />
 // ***********************************************
 // This example commands.ts shows you how to
 // create various custom commands and overwrite

--- a/package-lock.json
+++ b/package-lock.json
@@ -5416,6 +5416,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.9.18",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -5431,23 +5438,20 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
-      "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
+      "version": "18.3.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
-      "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
+      "version": "18.3.1",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.0.0"
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -25836,8 +25840,8 @@
         "@patternfly/patternfly": "^6.0.0",
         "@patternfly/patternfly-a11y": "^5.1.0",
         "@patternfly/react-code-editor": "^6.0.0",
-        "@types/react": "^19.1.0",
-        "@types/react-dom": "^19.1.2",
+        "@types/react": "^18.2.33",
+        "@types/react-dom": "^18.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "typescript": "^5.8.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5416,13 +5416,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/qs": {
       "version": "6.9.18",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -5438,20 +5431,23 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.3",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
+      "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.1",
+      "version": "19.1.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
+      "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@types/retry": {
@@ -25840,15 +25836,15 @@
         "@patternfly/patternfly": "^6.0.0",
         "@patternfly/patternfly-a11y": "^5.1.0",
         "@patternfly/react-code-editor": "^6.0.0",
-        "@types/react": "^18.2.33",
-        "@types/react-dom": "^18.3.1",
+        "@types/react": "^19.1.0",
+        "@types/react-dom": "^19.1.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
       }
     }
   }

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -38,16 +38,16 @@
     "clsx": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "^17 || ^18",
-    "react-dom": "^17 || ^18"
+    "react": "^17 || ^18 || ^19",
+    "react-dom": "^17 || ^18 || ^19"
   },
   "devDependencies": {
     "@patternfly/patternfly-a11y": "^5.1.0",
     "@patternfly/documentation-framework": "^6.5.16",
     "@patternfly/react-code-editor": "^6.0.0",
     "@patternfly/patternfly": "^6.0.0",
-    "@types/react": "^18.2.33",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typescript": "^5.8.3"

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -46,8 +46,8 @@
     "@patternfly/documentation-framework": "^6.5.16",
     "@patternfly/react-code-editor": "^6.0.0",
     "@patternfly/patternfly": "^6.0.0",
-    "@types/react": "^19.1.0",
-    "@types/react-dom": "^19.1.2",
+    "@types/react": "^18.2.33",
+    "@types/react-dom": "^18.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typescript": "^5.8.3"

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Ansible/Ansible.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Ansible/Ansible.md
@@ -15,12 +15,13 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import Ansible from '@patternfly/react-component-groups/dist/dynamic/Ansible';
+import { FunctionComponent } from 'react';
 
 The **Ansible** component displays the Ansible project logo, with a support status style.
 
 ### Ansible supported
 
-By default, the Ansible logo displays as normal and in full color, meaning that it is supported. 
+By default, the Ansible logo displays as normal and in full color, meaning that it is supported.
 
 ```js file="./AnsibleSupportedExample.tsx"
 
@@ -34,8 +35,7 @@ To specify that Ansible is not supported, set the `isSupported` property to `fal
 
 ```
 
-
-### Red Hat Ansible Automation Platform 
+### Red Hat Ansible Automation Platform
 
 To display the Red Hat Ansible Automation Platform, add the `isRHAAP` property to the `<Ansible>` component.
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Ansible/AnsibleSupportedExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Ansible/AnsibleSupportedExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Ansible from '@patternfly/react-component-groups/dist/dynamic/Ansible';
 
-export const BasicExample: React.FunctionComponent = () => <Ansible />;
+export const BasicExample: FunctionComponent = () => <Ansible />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Ansible/AnsibleTechnologyExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Ansible/AnsibleTechnologyExample.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Ansible from '@patternfly/react-component-groups/dist/dynamic/Ansible';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <Ansible isRHAAP/>
-);
+export const BasicExample: FunctionComponent = () => <Ansible isRHAAP />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Ansible/AnsibleUnsupportedExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Ansible/AnsibleUnsupportedExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Ansible from '@patternfly/react-component-groups/dist/dynamic/Ansible';
 
-export const BasicExample: React.FunctionComponent = () => <Ansible isSupported={false} />;
+export const BasicExample: FunctionComponent = () => <Ansible isSupported={false} />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/BulkSelect/BulkSelect.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/BulkSelect/BulkSelect.md
@@ -13,8 +13,9 @@ source: react
 propComponents: ['BulkSelect']
 sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/BulkSelect/BulkSelect.md
 ---
-import { useState } from 'react';
+
 import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
+import { FunctionComponent, useState } from 'react';
 
 The **bulk select** provides a way of selecting data records in batches. You can select all data at once, all data on current page or deselect all.
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/BulkSelect/BulkSelectAllExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/BulkSelect/BulkSelectAllExample.tsx
@@ -1,16 +1,16 @@
-import React, { useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
 
-const allData = [ "Item 1", "Item 2" , "Item 3", "Item4", "Item 5" ];
-const pageData = [ "Item 1", "Item 2" ];
+const allData = [ 'Item 1', 'Item 2', 'Item 3', 'Item4', 'Item 5' ];
+const pageData = [ 'Item 1', 'Item 2' ];
 
-export const BasicExample: React.FunctionComponent = () => { 
+export const BasicExample: FunctionComponent = () => {
   const [ selected, setSelected ] = useState<string[]>(pageData);
 
   const handleBulkSelect = (value: BulkSelectValue) => {
     value === BulkSelectValue.none && setSelected([]);
     value === BulkSelectValue.all && setSelected(allData);
-    value === BulkSelectValue.nonePage && setSelected(selected.filter(item => !pageData.includes(item)));
+    value === BulkSelectValue.nonePage && setSelected(selected.filter((item) => !pageData.includes(item)));
     value === BulkSelectValue.page && setSelected(Array.from(new Set([ ...selected, ...pageData ])));
   };
 
@@ -21,8 +21,10 @@ export const BasicExample: React.FunctionComponent = () => {
       pageCount={pageData.length}
       totalCount={allData.length}
       onSelect={handleBulkSelect}
-      pageSelected={pageData.every(item => selected.includes(item))}
-      pagePartiallySelected={pageData.some(item => selected.includes(item)) && !pageData.every(item => selected.includes(item))}
+      pageSelected={pageData.every((item) => selected.includes(item))}
+      pagePartiallySelected={
+        pageData.some((item) => selected.includes(item)) && !pageData.every((item) => selected.includes(item))
+      }
     />
   );
-}
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/BulkSelect/BulkSelectExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/BulkSelect/BulkSelectExample.tsx
@@ -1,16 +1,16 @@
-import React, { useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
 
-const allData = [ "Item 1", "Item 2" , "Item 3", "Item4", "Item 5" ];
-const pageData = [ "Item 1", "Item 2" ];
+const allData = [ 'Item 1', 'Item 2', 'Item 3', 'Item4', 'Item 5' ];
+const pageData = [ 'Item 1', 'Item 2' ];
 
-export const BasicExample: React.FunctionComponent = () => { 
+export const BasicExample: FunctionComponent = () => {
   const [ selected, setSelected ] = useState<string[]>([]);
 
   const handleBulkSelect = (value: BulkSelectValue) => {
     value === BulkSelectValue.none && setSelected([]);
     value === BulkSelectValue.all && setSelected(allData);
-    value === BulkSelectValue.nonePage && setSelected(selected.filter(item => !pageData.includes(item)));
+    value === BulkSelectValue.nonePage && setSelected(selected.filter((item) => !pageData.includes(item)));
     value === BulkSelectValue.page && setSelected(Array.from(new Set([ ...selected, ...pageData ])));
   };
 
@@ -19,8 +19,10 @@ export const BasicExample: React.FunctionComponent = () => {
       selectedCount={selected.length}
       pageCount={pageData.length}
       onSelect={handleBulkSelect}
-      pageSelected={pageData.every(item => selected.includes(item))}
-      pagePartiallySelected={pageData.some(item => selected.includes(item)) && !pageData.every(item => selected.includes(item))}
+      pageSelected={pageData.every((item) => selected.includes(item))}
+      pagePartiallySelected={
+        pageData.some((item) => selected.includes(item)) && !pageData.every((item) => selected.includes(item))
+      }
     />
   );
-}
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/CloseButton/CloseButton.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/CloseButton/CloseButton.md
@@ -16,6 +16,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 
 import { CloseIcon } from '@patternfly/react-icons';
 import CloseButton from '@patternfly/react-component-groups/dist/dynamic/CloseButton';
+import { FunctionComponent } from 'react';
 
 The **close button** component provides a way for users to exit a modal, dialogue, or similar action. To further customize this component, you can also utilize all properties of the [button component](/components/button).
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/CloseButton/CloseButtonExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/CloseButton/CloseButtonExample.tsx
@@ -1,9 +1,15 @@
 /* eslint-disable no-console */
-import React from 'react'
+import { FunctionComponent } from 'react';
 import CloseButton from '@patternfly/react-component-groups/dist/dynamic/CloseButton';
 
-export const BasicExample: React.FunctionComponent = () => (
+export const BasicExample: FunctionComponent = () => (
   <>
-    <CloseButton dataTestID="close-button-example" onClick={()=>{console.log('Close button clicked')}} style={{ float: 'none' }} />
+    <CloseButton
+      dataTestID="close-button-example"
+      onClick={() => {
+        console.log('Close button clicked');
+      }}
+      style={{ float: 'none' }}
+    />
   </>
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModal.md
@@ -16,6 +16,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 
 import ColumnManagementModal from '@patternfly/react-component-groups/dist/dynamic/ColumnManagementModal';
 import { ColumnsIcon } from '@patternfly/react-icons';
+import { FunctionComponent, useState } from 'react';
 
 The **column management modal** component can be used to implement customizable table columns. Columns can be configured to be enabled or disabled by default or be unhidable.
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ColumnManagementModal/ColumnManagementModalExample.tsx
@@ -1,8 +1,10 @@
-import React from 'react'
+import { FunctionComponent, useState } from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Tr, Thead } from '@patternfly/react-table';
 import { ColumnsIcon } from '@patternfly/react-icons';
-import ColumnManagementModal, { ColumnManagementModalColumn } from '@patternfly/react-component-groups/dist/dynamic/ColumnManagementModal';
+import ColumnManagementModal, {
+  ColumnManagementModalColumn
+} from '@patternfly/react-component-groups/dist/dynamic/ColumnManagementModal';
 
 const DEFAULT_COLUMNS: ColumnManagementModalColumn[] = [
   {
@@ -57,40 +59,50 @@ const ROWS = [
     impact: 'Moderate',
     score: '6.1'
   }
-]
+];
 
-export const ColumnManagementModalExample: React.FunctionComponent = () => {
-  const [ columns, setColumns ] = React.useState(DEFAULT_COLUMNS);
-  const [ isOpen, setOpen ] = React.useState(false);
-  
+export const ColumnManagementModalExample: FunctionComponent = () => {
+  const [ columns, setColumns ] = useState(DEFAULT_COLUMNS);
+  const [ isOpen, setOpen ] = useState(false);
+
   return (
     <>
       <ColumnManagementModal
         appliedColumns={columns}
-        applyColumns={newColumns => setColumns(newColumns)}
+        applyColumns={(newColumns) => setColumns(newColumns)}
         isOpen={isOpen}
         onClose={() => setOpen(false)}
       />
-      <Button className='pf-v6-u-mb-sm' onClick={() => setOpen(true)} variant={ButtonVariant.secondary} icon={<ColumnsIcon />}>Manage columns</Button>
-      <Table
-        aria-label="Simple table"
-        variant="compact"
+      <Button
+        className="pf-v6-u-mb-sm"
+        onClick={() => setOpen(true)}
+        variant={ButtonVariant.secondary}
+        icon={<ColumnsIcon />}
       >
+        Manage columns
+      </Button>
+      <Table aria-label="Simple table" variant="compact">
         <Thead>
           <Tr>
-            {columns.filter(column => column.isShown).map(column => <Th key={column.key}>{column.title}</Th>)}
+            {columns
+              .filter((column) => column.isShown)
+              .map((column) => (
+                <Th key={column.key}>{column.title}</Th>
+              ))}
           </Tr>
         </Thead>
         <Tbody>
-          {ROWS.map((row, rowIndex) => 
+          {ROWS.map((row, rowIndex) => (
             <Tr key={rowIndex}>
-              {columns.filter(column => column.isShown).map((column, columnIndex) =>
-                <Td key={columnIndex}>{row[column.key]}</Td>
-              )}
-            </Tr>  
-          )}
+              {columns
+                .filter((column) => column.isShown)
+                .map((column, columnIndex) => (
+                  <Td key={columnIndex}>{row[column.key]}</Td>
+                ))}
+            </Tr>
+          ))}
         </Tbody>
       </Table>
     </>
-  )
-}
+  );
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorBoundary/ErrorBoundary.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorBoundary/ErrorBoundary.md
@@ -13,13 +13,14 @@ source: react
 propComponents: ['ErrorBoundary']
 sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorBoundary/ErrorBoundary.md
 ---
-import { useState } from 'react';
+
 import { Button, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
 import ErrorBoundary from "@patternfly/react-component-groups/dist/dynamic/ErrorBoundary";
+import { FunctionComponent, useState } from 'react';
 
 The **error boundary** component repurposes the `<ErrorState>` component for an application error boundary.
 
-## Examples 
+## Examples
 
 ### Error boundary usage example
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorBoundary/ErrorBoundaryExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorBoundary/ErrorBoundaryExample.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { Title, Button, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
 import ErrorBoundary from '@patternfly/react-component-groups/dist/dynamic/ErrorBoundary';
 
-export const BasicExample: React.FunctionComponent = () => {
+export const BasicExample: FunctionComponent = () => {
   const [ hasError, setHasError ] = useState(false);
 
   const Surprise = () => {
@@ -12,16 +12,16 @@ export const BasicExample: React.FunctionComponent = () => {
     return (
       <Card>
         <CardHeader>
-          <Title headingLevel='h2'>Demo content wrapped in error boundary</Title>
+          <Title headingLevel="h2">Demo content wrapped in error boundary</Title>
         </CardHeader>
         <CardBody>This is a demo content that may throw an error:</CardBody>
         <CardFooter>
-          <Button className='pf-v6-u-mt-lg' variant='danger' onClick={() => setHasError(true)}>
+          <Button className="pf-v6-u-mt-lg" variant="danger" onClick={() => setHasError(true)}>
             Click to throw an error
           </Button>
         </CardFooter>
       </Card>
-    )
+    );
   };
 
   return (
@@ -29,13 +29,11 @@ export const BasicExample: React.FunctionComponent = () => {
       <ErrorBoundary errorTitle="Something wrong happened">
         <Surprise />
       </ErrorBoundary>
-      {
-        hasError && (
-          <Button className='pf-v6-u-mt-lg' variant='secondary' onClick={() => window.location.reload()}>
-            Reload page
-          </Button>
-        )
-      }
+      {hasError && (
+        <Button className="pf-v6-u-mt-lg" variant="secondary" onClick={() => window.location.reload()}>
+          Reload page
+        </Button>
+      )}
     </>
   );
 };

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorState/ErrorState.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorState/ErrorState.md
@@ -16,6 +16,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 
 import ErrorState from "@patternfly/react-component-groups/dist/dynamic/ErrorState";
 import { PathMissingIcon } from '@patternfly/react-icons/dist/dynamic/icons/path-missing-icon';
+import { FunctionComponent } from 'react';
 
 The **error state** component repurposes the `EmptyState` component to display an error to users. To further customize this component, you can also utilize all properties of the [empty state component](/components/empty-state), with the `exception` of `children`.
 
@@ -31,7 +32,7 @@ To provide users with error details, a basic error state should contain an appro
 
 ### Custom footer
 
-To override the default action button, specify your own using `customFooter`. 
+To override the default action button, specify your own using `customFooter`.
 
 ```js file="./ErrorStateFooterExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorState/ErrorStateExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorState/ErrorStateExample.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
-import ErrorState from "@patternfly/react-component-groups/dist/dynamic/ErrorState";
+import { FunctionComponent } from 'react';
+import ErrorState from '@patternfly/react-component-groups/dist/dynamic/ErrorState';
 
-export const BasicExample: React.FunctionComponent = () => <ErrorState titleText='Sample error title' bodyText='Sample error description' />;
+export const BasicExample: FunctionComponent = () => (
+  <ErrorState titleText="Sample error title" bodyText="Sample error description" />
+);

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorState/ErrorStateExtraProps.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorState/ErrorStateExtraProps.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import ErrorState from "@patternfly/react-component-groups/dist/dynamic/ErrorState";
+import { FunctionComponent } from 'react';
+import ErrorState from '@patternfly/react-component-groups/dist/dynamic/ErrorState';
 import { PathMissingIcon } from '@patternfly/react-icons/dist/dynamic/icons/path-missing-icon';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <ErrorState 
-    titleText='Sample error title' 
-    bodyText='Sample error description' 
-    headingLevel='h2'
+export const BasicExample: FunctionComponent = () => (
+  <ErrorState
+    titleText="Sample error title"
+    bodyText="Sample error description"
+    headingLevel="h2"
     icon={PathMissingIcon}
     status="none"
     customFooter="Any other details in a custom footer."

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorState/ErrorStateFooterExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ErrorState/ErrorStateFooterExample.tsx
@@ -1,8 +1,16 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import { Button } from '@patternfly/react-core';
-import ErrorState from "@patternfly/react-component-groups/dist/dynamic/ErrorState";
+import ErrorState from '@patternfly/react-component-groups/dist/dynamic/ErrorState';
 
-// eslint-disable-next-line no-console
-export const BasicExample: React.FunctionComponent = () => <ErrorState titleText='Sample error title' bodyText='Sample error description' customFooter={<Button variant="secondary" onClick={() => console.log("Custom button clicked")}>
-Custom action
-</Button>}/>;
+export const BasicExample: FunctionComponent = () => (
+  <ErrorState
+    titleText="Sample error title"
+    bodyText="Sample error description"
+    customFooter={
+      // eslint-disable-next-line no-console
+      <Button variant="secondary" onClick={() => console.log('Custom button clicked')}>
+        Custom action
+      </Button>
+    }
+  />
+);

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/LogSnippet/LogSnippet.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/LogSnippet/LogSnippet.md
@@ -15,12 +15,14 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import LogSnippet from '@patternfly/react-component-groups/dist/dynamic/LogSnippet';
+import { FunctionComponent } from 'react';
 
 A **log snippet** component provides a way to display a log snippet or code along with a message.
 
 ## Examples
 
 ### Basic log snippet
+
 The log snippet supports several variants configurable using `variant` property for different scenarios. Each variant has an associated status icon and color similar to [alert component](/components/alert).
 
 ```js file="./LogSnippetExample.tsx"

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/LogSnippet/LogSnippetExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/LogSnippet/LogSnippetExample.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import LogSnippet from '@patternfly/react-component-groups/dist/dynamic/LogSnippet';
 
-export const BasicExample: React.FunctionComponent = () => {
+export const BasicExample: FunctionComponent = () => {
   const code = `apiVersion: helm.openshift.io/v1beta1/
   kind: HelmChartRepository
   metadata:
@@ -10,5 +10,5 @@ export const BasicExample: React.FunctionComponent = () => {
   connectionConfig:
   url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
 
-  return <LogSnippet message='Failure - check logs for details' logSnippet={code} />;
-}
+  return <LogSnippet message="Failure - check logs for details" logSnippet={code} />;
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Maintenance/Maintenance.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Maintenance/Maintenance.md
@@ -15,6 +15,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import Maintenance from '@patternfly/react-component-groups/dist/dynamic/Maintenance';
+import { FunctionComponent } from 'react';
 
 A **maintenance** component displays a screen to users when they are undergoing scheduled maintenance.
 
@@ -22,7 +23,7 @@ A **maintenance** component displays a screen to users when they are undergoing 
 
 ### Basic maintenance
 
-To provide users with basic information regarding maintenance. A basic maintenance state should contain an appropriate and informative `titleText`. `defaultBodyText` will be used by default. 
+To provide users with basic information regarding maintenance. A basic maintenance state should contain an appropriate and informative `titleText`. `defaultBodyText` will be used by default.
 
 ```js file="./MaintenanceExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Maintenance/MaintenanceCustomExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Maintenance/MaintenanceCustomExample.tsx
@@ -1,6 +1,14 @@
-import React from 'react';
-import Maintenance from '@patternfly/react-component-groups/dist/dynamic/Maintenance'
+import { FunctionComponent } from 'react';
+import Maintenance from '@patternfly/react-component-groups/dist/dynamic/Maintenance';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <Maintenance bodyText='We are currently undergoing scheduled maintenance and will be unavailable from' customFooter='Please visit' redirectLinkUrl='http://patternfly.com' redirectLinkText='here.' startTime='6am' endTime='8am' timeZone='UTC' />
+export const BasicExample: FunctionComponent = () => (
+  <Maintenance
+    bodyText="We are currently undergoing scheduled maintenance and will be unavailable from"
+    customFooter="Please visit"
+    redirectLinkUrl="http://patternfly.com"
+    redirectLinkText="here."
+    startTime="6am"
+    endTime="8am"
+    timeZone="UTC"
+  />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Maintenance/MaintenanceExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Maintenance/MaintenanceExample.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
-import Maintenance from '@patternfly/react-component-groups/dist/dynamic/Maintenance'
+import { FunctionComponent } from 'react';
+import Maintenance from '@patternfly/react-component-groups/dist/dynamic/Maintenance';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <Maintenance />
-);
+export const BasicExample: FunctionComponent = () => <Maintenance />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MissingPage/MissingPage.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MissingPage/MissingPage.md
@@ -15,6 +15,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import MissingPage from '@patternfly/react-component-groups/dist/dynamic/MissingPage';
+import { FunctionComponent } from 'react';
 
 The **missing page** component can be used to display an error message and "return to homepage" button when an error occurs.
 
@@ -22,7 +23,7 @@ The **missing page** component can be used to display an error message and "retu
 
 ### Basic missing page
 
-A basic missing page component informs users that an error has occurred. It also includes a button link, which users can select to return to the homepage.  
+A basic missing page component informs users that an error has occurred. It also includes a button link, which users can select to return to the homepage.
 
 ```js file="./MissingPageExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MissingPage/MissingPageExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MissingPage/MissingPageExample.tsx
@@ -1,4 +1,4 @@
 import MissingPage from '@patternfly/react-component-groups/dist/dynamic/MissingPage';
-import React from 'react';
+import { FunctionComponent } from 'react';
 
-export const BasicExample: React.FunctionComponent = () => <MissingPage />;
+export const BasicExample: FunctionComponent = () => <MissingPage />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCard.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCard.md
@@ -11,6 +11,7 @@ import MultiContentCard, { MultiContentCardDividerVariant } from "@patternfly/re
 import { ArrowRightIcon, BellIcon, CogIcon, EllipsisVIcon, LockIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
+import { FunctionComponent, useState } from 'react';
 
 A **multi-content card** component allows to display multiple card components in a single layout. To further customize this layout, you can also utilize all properties of the [card component](/components/card), with the exception of `children` and `title`.
 
@@ -42,7 +43,7 @@ Actions can be displayed in the multi-content card heading using `actions` prope
 
 ### Expandable multi content card with dividers
 
-Dividers between all cards in the content can be shown using `withDividers` flag. 
+Dividers between all cards in the content can be shown using `withDividers` flag.
 
 ```js file="./MultiContentCardExpandableDividerExample.tsx"
 
@@ -50,7 +51,7 @@ Dividers between all cards in the content can be shown using `withDividers` flag
 
 ### Expandable multi-content card with single dividers
 
-To enable a divider just for a single card, use `dividerVariant` property passed to the `cards` array. 
+To enable a divider just for a single card, use `dividerVariant` property passed to the `cards` array.
 
 ```js file="./MultiContentCardExpandableSingleDividerExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExample.tsx
@@ -1,6 +1,17 @@
-import React from 'react';
-import MultiContentCard from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
-import { Button, Card, CardHeader, CardBody, CardFooter, List, ListItem, Content, ContentVariants, Icon } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+import MultiContentCard from '@patternfly/react-component-groups/dist/dynamic/MultiContentCard';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  List,
+  ListItem,
+  Content,
+  ContentVariants,
+  Icon
+} from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, LockIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
@@ -8,17 +19,17 @@ import clsx from 'clsx';
 const useStyles = createUseStyles({
   action: {
     color: 'var(--pf-t--global--text--color--brand--default)',
-    fontSize: 'var(--pf-t--global--font--size--sm)',
+    fontSize: 'var(--pf-t--global--font--size--sm)'
   },
   actionIcon: {
-    color: 'var(--pf-t--global--icon--color--regular)',
+    color: 'var(--pf-t--global--icon--color--regular)'
   },
   bulletPoints: {
-    color: 'var(--pf-t--global--color--brand--default)',
-  },
+    color: 'var(--pf-t--global--color--brand--default)'
+  }
 });
 
-export const BasicExample: React.FunctionComponent = () => {
+export const BasicExample: FunctionComponent = () => {
   const classes = useStyles();
   const cards = [
     <Card isFullHeight isPlain key="card-1">
@@ -33,19 +44,26 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure application
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <List className={clsx(classes.bulletPoints, 'pf-v6-u-font-size-sm', 'pf-v6-u-ml-0')}>
           <ListItem>
-            <Button variant="link" isInline>First link</Button>
+            <Button variant="link" isInline>
+              First link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Second link</Button>
+            <Button variant="link" isInline>
+              Second link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Another link</Button>
+            <Button variant="link" isInline>
+              Another link
+            </Button>
           </ListItem>
         </List>
       </CardFooter>
@@ -60,16 +78,23 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure access
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon />
-          </Icon>} variant="link" isInline>
-            Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
@@ -86,21 +111,27 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure notifications
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon />
-          </Icon>} variant="link" isInline>
-            Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
     </Card>
   ];
 
-  return(<MultiContentCard cards={cards} />);
-}
+  return <MultiContentCard cards={cards} />;
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableActionsExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableActionsExample.tsx
@@ -1,24 +1,42 @@
-import React from 'react';
-import MultiContentCard from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
+import { FunctionComponent, useState } from 'react';
+import MultiContentCard from '@patternfly/react-component-groups/dist/dynamic/MultiContentCard';
 import { EllipsisVIcon } from '@patternfly/react-icons';
-import { Button, Card, CardHeader, CardBody, CardFooter, Content, ContentVariants, List, ListItem, Icon, Divider, Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement, Label } from '@patternfly/react-core';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  Content,
+  ContentVariants,
+  List,
+  ListItem,
+  Icon,
+  Divider,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+  Label
+} from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, LockIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
 
 const useStyles = createUseStyles({
   bulletPoints: {
-    color: 'var(--pf-t--global--color--brand--default)',
-  },
+    color: 'var(--pf-t--global--color--brand--default)'
+  }
 });
 
-export const BasicExample: React.FunctionComponent = () => {
+export const BasicExample: FunctionComponent = () => {
   const classes = useStyles();
-  const [ isMenuOpen, setMenuOpen ] = React.useState(false)
+  const [ isMenuOpen, setMenuOpen ] = useState(false);
 
   const cards = [
     <Card isFullHeight isPlain key="card-1">
-      <CardHeader  className="pf-v6-u-pt-0">
+      <CardHeader className="pf-v6-u-pt-0">
         <Content component={ContentVariants.h4}>Getting Started</Content>
       </CardHeader>
       <CardBody>
@@ -26,37 +44,56 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure application
         </Label>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <List className={clsx(classes.bulletPoints, 'pf-v6-u-font-size-sm', 'pf-v6-u-ml-0')}>
           <ListItem>
-            <Button variant="link" isInline>First link</Button>
+            <Button variant="link" isInline>
+              First link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Second link</Button>
+            <Button variant="link" isInline>
+              Second link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Another link</Button>
+            <Button variant="link" isInline>
+              Another link
+            </Button>
           </ListItem>
         </List>
       </CardFooter>
     </Card>,
     <Card isFullHeight isPlain key="card-2">
-      <CardHeader className="pf-v6-u-pt-0" style={{ visibility: 'hidden' }}>-</CardHeader>
+      <CardHeader className="pf-v6-u-pt-0" style={{ visibility: 'hidden' }}>
+        -
+      </CardHeader>
       <CardBody>
         <Label className="pf-v6-u-mb-sm" icon={<LockIcon />} color="green">
           Configure access
         </Label>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline><ArrowRightIcon /></Icon>} variant="link" isInline>
-            Learn more   
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
@@ -70,13 +107,22 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure notifications
         </Label>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline><ArrowRightIcon /></Icon>} variant="link" isInline>
-            Learn more    
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
@@ -87,9 +133,9 @@ export const BasicExample: React.FunctionComponent = () => {
     setMenuOpen(!isMenuOpen);
   };
   return (
-    <MultiContentCard 
+    <MultiContentCard
       isExpandable
-      toggleText='Card with actions toggle text' 
+      toggleText="Card with actions toggle text"
       cards={cards}
       actions={
         <Dropdown
@@ -97,7 +143,7 @@ export const BasicExample: React.FunctionComponent = () => {
           onSelect={() => null}
           onOpenChange={(isMenuOpen: boolean) => setMenuOpen(isMenuOpen)}
           popperProps={{ position: 'right' }}
-          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          toggle={(toggleRef: Ref<MenuToggleElement>) => (
             <MenuToggle
               ref={toggleRef}
               aria-label="kebab dropdown toggle"
@@ -112,18 +158,18 @@ export const BasicExample: React.FunctionComponent = () => {
         >
           <DropdownList>
             <DropdownItem value={0} key="action">
-            Action
+              Action
             </DropdownItem>
             <DropdownItem value={1} isDisabled key="disabled action">
-            Disabled Action
+              Disabled Action
             </DropdownItem>
             <Divider component="li" key="separator" />
             <DropdownItem value={2} key="separated action">
-            Separated Action
+              Separated Action
             </DropdownItem>
           </DropdownList>
         </Dropdown>
       }
     />
-  )
+  );
 };

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableDividerExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableDividerExample.tsx
@@ -1,6 +1,17 @@
-import React from 'react';
-import MultiContentCard from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
-import { Button, Card, CardHeader, CardBody, CardFooter, List, ListItem, Content, ContentVariants, Icon } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+import MultiContentCard from '@patternfly/react-component-groups/dist/dynamic/MultiContentCard';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  List,
+  ListItem,
+  Content,
+  ContentVariants,
+  Icon
+} from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, LockIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
@@ -8,17 +19,17 @@ import clsx from 'clsx';
 const useStyles = createUseStyles({
   action: {
     color: 'var(--pf-t--global--text--color--brand--default)',
-    fontSize: 'var(--pf-t--global--font--size--sm)',
+    fontSize: 'var(--pf-t--global--font--size--sm)'
   },
   actionIcon: {
-    color: 'var(--pf-t--global--icon--color--regular)',
+    color: 'var(--pf-t--global--icon--color--regular)'
   },
   bulletPoints: {
-    color: 'var(--pf-t--global--color--brand--default)',
-  },
+    color: 'var(--pf-t--global--color--brand--default)'
+  }
 });
 
-export const BasicExample: React.FunctionComponent = () => {
+export const BasicExample: FunctionComponent = () => {
   const classes = useStyles();
 
   const cards = [
@@ -31,46 +42,62 @@ export const BasicExample: React.FunctionComponent = () => {
           <Icon size="md" className="pf-v6-u-pl-sm pf-v6-u-pr-md">
             <CogIcon className={classes.actionIcon} />
           </Icon>
-            Configure application
+          Configure application
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <List className={clsx(classes.bulletPoints, 'pf-v6-u-font-size-sm', 'pf-v6-u-ml-0')}>
           <ListItem>
-            <Button variant="link" isInline>First link</Button>
+            <Button variant="link" isInline>
+              First link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Second link</Button>
+            <Button variant="link" isInline>
+              Second link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Another link</Button>
+            <Button variant="link" isInline>
+              Another link
+            </Button>
           </ListItem>
         </List>
       </CardFooter>
     </Card>,
     <Card isFullHeight isPlain key="card-2">
-      <CardHeader className='pf-v6-u-pt-0' style={{ visibility: 'hidden' }}>-</CardHeader>
+      <CardHeader className="pf-v6-u-pt-0" style={{ visibility: 'hidden' }}>
+        -
+      </CardHeader>
       <CardBody>
         <Content className={clsx(classes.action, 'pf-v6-u-font-weight-bold', 'pf-v6-u-mb-sm')}>
           <Icon size="md" className="pf-v6-u-pl-sm pf-v6-u-pr-md">
             <LockIcon className={classes.actionIcon} />
           </Icon>
-            Configure access
+          Configure access
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon className={classes.action} />
-          </Icon>} variant="link" isInline>
-              Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon className={classes.action} />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
@@ -84,22 +111,29 @@ export const BasicExample: React.FunctionComponent = () => {
           <Icon size="md" className="pf-v6-u-pl-sm pf-v6-u-pr-md">
             <BellIcon className={classes.actionIcon} />
           </Icon>
-            Configure notifications
+          Configure notifications
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon />
-          </Icon>} variant="link" isInline>
-              Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
     </Card>
   ];
-  return (<MultiContentCard isExpandable withDividers toggleText='Card with dividers toggle text' cards={cards} />)};
+  return <MultiContentCard isExpandable withDividers toggleText="Card with dividers toggle text" cards={cards} />;
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableExample.tsx
@@ -1,6 +1,17 @@
-import React from 'react';
-import MultiContentCard from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
-import { Button, Card, CardHeader, CardBody, CardFooter, List, ListItem, Content, ContentVariants, Icon } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+import MultiContentCard from '@patternfly/react-component-groups/dist/dynamic/MultiContentCard';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  List,
+  ListItem,
+  Content,
+  ContentVariants,
+  Icon
+} from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, LockIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
@@ -8,17 +19,17 @@ import clsx from 'clsx';
 const useStyles = createUseStyles({
   action: {
     color: 'var(--pf-t--global--text--color--brand--default)',
-    fontSize: 'var(--pf-t--global--font--size--sm)',
+    fontSize: 'var(--pf-t--global--font--size--sm)'
   },
   actionIcon: {
-    color: 'var(--pf-t--global--icon--color--regular)',
+    color: 'var(--pf-t--global--icon--color--regular)'
   },
   bulletPoints: {
-    color: 'var(--pf-t--global--color--brand--default)',
-  },
+    color: 'var(--pf-t--global--color--brand--default)'
+  }
 });
 
-export const BasicExample: React.FunctionComponent = () => {
+export const BasicExample: FunctionComponent = () => {
   const classes = useStyles();
   const cards = [
     <Card isFullHeight isPlain key="card-1">
@@ -33,25 +44,34 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure application
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <List className={clsx(classes.bulletPoints, 'pf-v6-u-font-size-sm', 'pf-v6-u-ml-0')}>
           <ListItem>
-            <Button variant="link" isInline>First link</Button>
+            <Button variant="link" isInline>
+              First link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Second link</Button>
+            <Button variant="link" isInline>
+              Second link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Another link</Button>
+            <Button variant="link" isInline>
+              Another link
+            </Button>
           </ListItem>
         </List>
       </CardFooter>
     </Card>,
     <Card isFullHeight isPlain key="card-2">
-      <CardHeader className='pf-v6-u-pt-0' style={{ visibility: 'hidden' }}>-</CardHeader>
+      <CardHeader className="pf-v6-u-pt-0" style={{ visibility: 'hidden' }}>
+        -
+      </CardHeader>
       <CardBody>
         <Content className={clsx(classes.action, 'pf-v6-u-font-weight-bold', 'pf-v6-u-mb-sm')}>
           <Icon size="md" className="pf-v6-u-pl-sm pf-v6-u-pr-md">
@@ -60,16 +80,23 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure access
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon />
-          </Icon>} variant="link" isInline>
-            Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
@@ -86,21 +113,27 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure notifications
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon />
-          </Icon>} variant="link" isInline>
-            Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
     </Card>
   ];
 
-  return(<MultiContentCard isExpandable toggleText='Expandable card toggle text' cards={cards} />);
-}
+  return <MultiContentCard isExpandable toggleText="Expandable card toggle text" cards={cards} />;
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableSingleDividerExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/MultiContentCard/MultiContentCardExpandableSingleDividerExample.tsx
@@ -1,6 +1,19 @@
-import React from 'react';
-import MultiContentCard, { MultiContentCardDividerVariant } from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
-import { Button, Card, CardHeader, CardBody, CardFooter, Content, List, ListItem, ContentVariants, Icon } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+import MultiContentCard, {
+  MultiContentCardDividerVariant
+} from '@patternfly/react-component-groups/dist/dynamic/MultiContentCard';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  Content,
+  List,
+  ListItem,
+  ContentVariants,
+  Icon
+} from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, LockIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss';
 import clsx from 'clsx';
@@ -8,17 +21,17 @@ import clsx from 'clsx';
 const useStyles = createUseStyles({
   action: {
     color: 'var(--pf-t--global--text--color--brand--default)',
-    fontSize: 'var(--pf-t--global--font--size--sm)',
+    fontSize: 'var(--pf-t--global--font--size--sm)'
   },
   actionIcon: {
-    color: 'var(--pf-t--global--icon--color--regular)',
+    color: 'var(--pf-t--global--icon--color--regular)'
   },
   bulletPoints: {
-    color: 'var(--pf-t--global--color--brand--default)',
-  },
+    color: 'var(--pf-t--global--color--brand--default)'
+  }
 });
 
-export const BasicExample: React.FunctionComponent = () => {
+export const BasicExample: FunctionComponent = () => {
   const classes = useStyles();
 
   const cards = [
@@ -34,25 +47,34 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure application
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
         </Content>
       </CardBody>
       <CardFooter>
         <List className={clsx(classes.bulletPoints, 'pf-v6-u-font-size-sm', 'pf-v6-u-ml-0')}>
           <ListItem>
-            <Button variant="link" isInline>First link</Button>
+            <Button variant="link" isInline>
+              First link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Second link</Button>
+            <Button variant="link" isInline>
+              Second link
+            </Button>
           </ListItem>
           <ListItem>
-            <Button variant="link" isInline>Another link</Button>
+            <Button variant="link" isInline>
+              Another link
+            </Button>
           </ListItem>
         </List>
       </CardFooter>
     </Card>,
     <Card isFullHeight isPlain key="card-2">
-      <CardHeader className='pf-v6-u-pt-0' style={{ visibility: 'hidden' }}>-</CardHeader>
+      <CardHeader className="pf-v6-u-pt-0" style={{ visibility: 'hidden' }}>
+        -
+      </CardHeader>
       <CardBody>
         <Content className={clsx(classes.action, 'pf-v6-u-font-weight-bold', 'pf-v6-u-mb-sm')}>
           <Icon size="md" className="pf-v6-u-pl-sm pf-v6-u-pr-md">
@@ -61,16 +83,23 @@ export const BasicExample: React.FunctionComponent = () => {
           Configure access
         </Content>
         <Content className="pf-v6-u-font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat.
         </Content>
       </CardBody>
       <CardFooter>
         <Content>
-          <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-            <ArrowRightIcon />
-          </Icon>} variant="link" isInline>
-            Learn more  
-            
+          <Button
+            icon={
+              <Icon className="pf-v6-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            }
+            variant="link"
+            isInline
+          >
+            Learn more
           </Button>
         </Content>
       </CardFooter>
@@ -89,23 +118,30 @@ export const BasicExample: React.FunctionComponent = () => {
               Configure notifications
             </Content>
             <Content className="pf-v6-u-font-size-sm">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua.
             </Content>
           </CardBody>
           <CardFooter>
             <Content>
-              <Button icon={<Icon className="pf-v6-u-ml-sm" isInline>
-                <ArrowRightIcon />
-              </Icon>} variant="link" isInline>
-              Learn more  
-                
+              <Button
+                icon={
+                  <Icon className="pf-v6-u-ml-sm" isInline>
+                    <ArrowRightIcon />
+                  </Icon>
+                }
+                variant="link"
+                isInline
+              >
+                Learn more
               </Button>
             </Content>
           </CardFooter>
         </Card>
-      ), 
+      ),
       dividerVariant: MultiContentCardDividerVariant.left
     }
   ];
 
-  return(<MultiContentCard isExpandable toggleText='Card with dividers toggle text' cards={cards} />);}
+  return <MultiContentCard isExpandable toggleText="Card with dividers toggle text" cards={cards} />;
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeader.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeader.md
@@ -10,6 +10,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 import PageHeader from "@patternfly/react-component-groups/dist/dynamic/PageHeader"
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import pageHeaderIcon from '../../assets/icons/page-header-icon.svg'
+import { Fragment, FunctionComponent, MouseEvent, Ref, useState } from 'react';
 
 The **page header** component displays a page header section with a title, subtitle and other optional content.
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderActionsExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderActionsExample.tsx
@@ -1,16 +1,24 @@
-import React from 'react';
+import { Fragment, FunctionComponent, MouseEvent, Ref, useState } from 'react';
 import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader';
-import { ActionList, ActionListItem, Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import {
+  ActionList,
+  ActionListItem,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement
+} from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
-export const ActionsExample: React.FunctionComponent = () => {
-  const [ isOpen, setIsOpen ] = React.useState(false);
+export const ActionsExample: FunctionComponent = () => {
+  const [ isOpen, setIsOpen ] = useState(false);
 
   const onToggle = () => {
     setIsOpen(!isOpen);
   };
 
-  const onSelect = (event: React.MouseEvent<Element, MouseEvent> | undefined) => {
+  const onSelect = (event: MouseEvent<Element, MouseEvent> | undefined) => {
     event?.stopPropagation();
     setIsOpen(!isOpen);
   };
@@ -26,19 +34,19 @@ export const ActionsExample: React.FunctionComponent = () => {
       </DropdownItem>
     </>
   );
-      
+
   return (
-    <React.Fragment>
+    <Fragment>
       <PageHeader
-        title='My Title'
-        subtitle='This is a subtitle for your page header' 
+        title="My Title"
+        subtitle="This is a subtitle for your page header"
         actionMenu={
           <ActionList>
             <ActionListItem>
               <Dropdown
                 popperProps={{ position: 'right' }}
                 onSelect={onSelect}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                toggle={(toggleRef: Ref<MenuToggleElement>) => (
                   <MenuToggle
                     ref={toggleRef}
                     icon={<EllipsisVIcon />}
@@ -55,8 +63,8 @@ export const ActionsExample: React.FunctionComponent = () => {
               </Dropdown>
             </ActionListItem>
           </ActionList>
-        } 
+        }
       />
-    </React.Fragment>
-  )
+    </Fragment>
+  );
 };

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderBreadcrumbExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderBreadcrumbExample.tsx
@@ -1,33 +1,23 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
-export const BreadcrumbExample: React.FunctionComponent = () => (
-  <PageHeader 
-    breadcrumbs={ 
+export const BreadcrumbExample: FunctionComponent = () => (
+  <PageHeader
+    breadcrumbs={
       <Breadcrumb>
-        <BreadcrumbItem
-          to="#"
-          key="home"
-        >
-        Home
+        <BreadcrumbItem to="#" key="home">
+          Home
         </BreadcrumbItem>
-        <BreadcrumbItem
-          to="#"
-          key="services"
-        >
-        Services
+        <BreadcrumbItem to="#" key="services">
+          Services
         </BreadcrumbItem>
-        <BreadcrumbItem
-          isActive
-          to="#"
-          key="serviceA"
-        >
-        Service A
+        <BreadcrumbItem isActive to="#" key="serviceA">
+          Service A
         </BreadcrumbItem>
       </Breadcrumb>
     }
-    title='My Title'
-    subtitle='This is a subtitle for your page header' 
+    title="My Title"
+    subtitle="This is a subtitle for your page header"
   />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderExample.tsx
@@ -1,9 +1,6 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <PageHeader 
-    title='My Title'
-    subtitle='This is a subtitle for your page header' 
-  />
+export const BasicExample: FunctionComponent = () => (
+  <PageHeader title="My Title" subtitle="This is a subtitle for your page header" />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderIconExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderIconExample.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader';
 import pageHeaderIcon from '../../assets/icons/page-header-icon.svg';
 
-
-export const IconExample: React.FunctionComponent = () => (
-  <PageHeader 
-    title='My Title'
-    subtitle='This is a subtitle for your page header' 
+export const IconExample: FunctionComponent = () => (
+  <PageHeader
+    title="My Title"
+    subtitle="This is a subtitle for your page header"
     icon={<img src={pageHeaderIcon} alt="page-header-icon" />}
   />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderLabelLinkExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/PageHeader/PageHeaderLabelLinkExample.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader';
 import { Label } from '@patternfly/react-core';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <PageHeader 
-    title='My Title'
-    subtitle='This is a subtitle for your page header'
+export const BasicExample: FunctionComponent = () => (
+  <PageHeader
+    title="My Title"
+    subtitle="This is a subtitle for your page header"
     label={<Label className="pf-v5-u-align-content-center">Org. Administrator</Label>}
     linkProps={{
       label: 'Go to this link',
-      isExternal: true,
+      isExternal: true
     }}
   />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActions.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActions.md
@@ -13,9 +13,10 @@ source: react
 propComponents: ['ResponsiveAction', 'ResponsiveActions']
 sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActions.md
 ---
-import { useState } from 'react';
+
 import { ResponsiveAction } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveAction';
 import { ResponsiveActions } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveActions';
+import { FunctionComponent, useState, useRef } from 'react';
 
 The **responsive actions** component allows for the display of actions in a responsive layout. Actions can be presented as persistent, pinned or collapsed to dropdown.
 
@@ -27,7 +28,6 @@ The `ResponsiveAction` component is used to declare individual actions within th
 
 This example demonstrates how to create responsive actions with persistent and pinned actions.
 
-
 ```js file="./ResponsiveActionsExample.tsx"
 
 ```
@@ -37,7 +37,6 @@ This example demonstrates how to create responsive actions with persistent and p
 By passing in the `breakpointReference` property, the overflow menu's breakpoint will be relative to the width of the reference container rather than the viewport width.
 
 You can change the container width in this example by adjusting the slider. As the container width changes, the actions will change their layout despite the viewport width not changing.
-
 
 ```js file="./ResponsiveActionsBreakpointExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActionsBreakpointExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActionsBreakpointExample.tsx
@@ -1,14 +1,11 @@
-import React from 'react';
-import {
-  Slider,
-  SliderOnChangeEvent,
-} from '@patternfly/react-core';
+import { FunctionComponent, useState, useRef } from 'react';
+import { Slider, SliderOnChangeEvent } from '@patternfly/react-core';
 import { ResponsiveActions } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveActions';
 import { ResponsiveAction } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveAction';
 
-export const ResponsiveActionsBreakpointExample: React.FunctionComponent = () => {
-  const [ containerWidth, setContainerWidth ] = React.useState(100);
-  const containerRef = React.useRef<HTMLDivElement>(null);
+export const ResponsiveActionsBreakpointExample: FunctionComponent = () => {
+  const [ containerWidth, setContainerWidth ] = useState(100);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const onChange = (_event: SliderOnChangeEvent, value: number) => {
     setContainerWidth(value);
@@ -25,8 +22,8 @@ export const ResponsiveActionsBreakpointExample: React.FunctionComponent = () =>
     <>
       <div style={{ width: '100%', maxWidth: '400px' }}>
         <div>
-          <span id="responsiveActions-hasBreakpointOnContainer-slider-label">Current container width</span>: {containerWidth}
-          %
+          <span id="responsiveActions-hasBreakpointOnContainer-slider-label">Current container width</span>:{' '}
+          {containerWidth}%
         </div>
         <Slider
           value={containerWidth}
@@ -41,18 +38,14 @@ export const ResponsiveActionsBreakpointExample: React.FunctionComponent = () =>
       </div>
       <div ref={containerRef} id="breakpoint-reference-container" style={containerStyles}>
         <ResponsiveActions breakpoint="sm" breakpointReference={containerRef}>
-          <ResponsiveAction isPersistent>
-            Persistent Action
-          </ResponsiveAction>
-          <ResponsiveAction isPinned variant='secondary'>
+          <ResponsiveAction isPersistent>Persistent Action</ResponsiveAction>
+          <ResponsiveAction isPinned variant="secondary">
             Pinned Action 1
           </ResponsiveAction>
-          <ResponsiveAction isPinned variant='secondary'>
+          <ResponsiveAction isPinned variant="secondary">
             Pinned Action 2
           </ResponsiveAction>
-          <ResponsiveAction>
-            Overflow Action
-          </ResponsiveAction>
+          <ResponsiveAction>Overflow Action</ResponsiveAction>
         </ResponsiveActions>
       </div>
     </>

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActionsExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ResponsiveActions/ResponsiveActionsExample.tsx
@@ -1,20 +1,14 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import { ResponsiveAction } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveAction';
 import { ResponsiveActions } from '@patternfly/react-component-groups/dist/dynamic/ResponsiveActions';
 
-export const TagCountDisabledExample: React.FunctionComponent = () => (
+export const TagCountDisabledExample: FunctionComponent = () => (
   <ResponsiveActions breakpoint="lg">
-    <ResponsiveAction isPersistent>
-        Persistent Action
+    <ResponsiveAction isPersistent>Persistent Action</ResponsiveAction>
+    <ResponsiveAction isPinned variant="secondary">
+      Pinned Action
     </ResponsiveAction>
-    <ResponsiveAction isPinned variant='secondary'>
-        Pinned Action
-    </ResponsiveAction>
-    <ResponsiveAction>
-        Overflow Action
-    </ResponsiveAction>
-    <ResponsiveAction isDisabled>
-        Disabled action
-    </ResponsiveAction>
+    <ResponsiveAction>Overflow Action</ResponsiveAction>
+    <ResponsiveAction isDisabled>Disabled action</ResponsiveAction>
   </ResponsiveActions>
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ServiceCard/ServiceCard.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ServiceCard/ServiceCard.md
@@ -10,6 +10,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 import ServiceCard from "@patternfly/react-component-groups/dist/dynamic/ServiceCard";
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import pageHeaderIcon from '../../assets/icons/page-header-icon.svg'
+import { FunctionComponent } from 'react'
 
 The **service card** component displays a card representing a service with an icon, title, description, and an optional customized footer
 
@@ -38,4 +39,3 @@ This shows how cards can look side by side in a [gallery layout](/layouts/galler
 ```js file="./ServiceCardGalleryExample.tsx"
 
 ```
-

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ServiceCard/ServiceCardExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ServiceCard/ServiceCardExample.tsx
@@ -1,32 +1,27 @@
-import React from 'react';
-import ServiceCard from "@patternfly/react-component-groups/dist/dynamic/ServiceCard";
+import { FunctionComponent } from 'react';
+import ServiceCard from '@patternfly/react-component-groups/dist/dynamic/ServiceCard';
 import pageHeaderIcon from '../../assets/icons/page-header-icon.svg';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 
-export const BasicExample: React.FunctionComponent = () => (
+export const BasicExample: FunctionComponent = () => (
   <ServiceCard
-    title='PatternFly'
-    subtitle='Component groups'
-    description='This is a sample service description'
+    title="PatternFly"
+    subtitle="Component groups"
+    description="This is a sample service description"
     icon={<img src={pageHeaderIcon} alt="page-header-icon" />}
-    helperText='Here is helper text'
+    helperText="Here is helper text"
     footer={
       <>
         <Button
           variant={ButtonVariant.secondary}
-          className='pf-v6-u-mr-md'
-          component='a'
-          href='https://patternfly.org'
-          target='_blank'
+          className="pf-v6-u-mr-md"
+          component="a"
+          href="https://patternfly.org"
+          target="_blank"
         >
           Launch
         </Button>
-        <Button
-          variant={ButtonVariant.link}
-          component='a'
-          href='https://patternfly.org'
-          target='_blank'
-        >
+        <Button variant={ButtonVariant.link} component="a" href="https://patternfly.org" target="_blank">
           Learn more
         </Button>
       </>

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ServiceCard/ServiceCardGalleryExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ServiceCard/ServiceCardGalleryExample.tsx
@@ -1,52 +1,47 @@
-import React from 'react';
-import ServiceCard from "@patternfly/react-component-groups/dist/dynamic/ServiceCard";
+import { FunctionComponent } from 'react';
+import ServiceCard from '@patternfly/react-component-groups/dist/dynamic/ServiceCard';
 import { Gallery } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
 import { GalleryItem } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import pageHeaderIcon from '../../assets/icons/page-header-icon.svg';
 
-export const ServiceCardGalleryExample: React.FunctionComponent = () => (
+export const ServiceCardGalleryExample: FunctionComponent = () => (
   <Gallery hasGutter minWidths={{ default: '330px' }}>
     <GalleryItem>
       <ServiceCard
         isStacked
-        title='Example1'
-        subtitle='A basic example'
-        description='This is a basic ServiceCard example'
+        title="Example1"
+        subtitle="A basic example"
+        description="This is a basic ServiceCard example"
         icon={<img src={pageHeaderIcon} alt="page-header-icon" />}
-        helperText='Example helper text'
+        helperText="Example helper text"
       />
     </GalleryItem>
     <GalleryItem>
       <ServiceCard
         isStacked
-        title='Example2'
-        subtitle='A second example'
-        description='This is another basic ServiceCard example'
+        title="Example2"
+        subtitle="A second example"
+        description="This is another basic ServiceCard example"
         icon={<img src={pageHeaderIcon} alt="page-header-icon" />}
-        helperText='Example helper text'
+        helperText="Example helper text"
         footer={
           <>
             <Button
               variant={ButtonVariant.secondary}
-              className='pf-v6-u-mr-md'
-              component='a'
-              href='https://patternfly.org'
-              target='_blank'
+              className="pf-v6-u-mr-md"
+              component="a"
+              href="https://patternfly.org"
+              target="_blank"
             >
-            Launch
+              Launch
             </Button>
-            <Button
-              variant={ButtonVariant.link}
-              component='a'
-              href='https://patternfly.org'
-              target='_blank'
-            >
-            Learn more
+            <Button variant={ButtonVariant.link} component="a" href="https://patternfly.org" target="_blank">
+              Learn more
             </Button>
           </>
         }
       />
     </GalleryItem>
   </Gallery>
-)
+);

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ServiceCard/ServiceCardStackedExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ServiceCard/ServiceCardStackedExample.tsx
@@ -1,34 +1,28 @@
-import React from 'react';
-import ServiceCard from "@patternfly/react-component-groups/dist/dynamic/ServiceCard";
+import { FunctionComponent } from 'react';
+import ServiceCard from '@patternfly/react-component-groups/dist/dynamic/ServiceCard';
 import pageHeaderIcon from '../../assets/icons/page-header-icon.svg';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 
-
-export const BasicExample: React.FunctionComponent = () => (
+export const BasicExample: FunctionComponent = () => (
   <ServiceCard
     isStacked
-    title='Example'
-    subtitle='A basic example'
-    description='This is a basic ServiceCard Example'
+    title="Example"
+    subtitle="A basic example"
+    description="This is a basic ServiceCard Example"
     icon={<img src={pageHeaderIcon} alt="page-header-icon" />}
-    helperText='Here is helper text'
+    helperText="Here is helper text"
     footer={
       <>
         <Button
           variant={ButtonVariant.secondary}
-          className='pf-v6-u-mr-md'
-          component='a'
-          href='https://patternfly.org'
-          target='_blank'
+          className="pf-v6-u-mr-md"
+          component="a"
+          href="https://patternfly.org"
+          target="_blank"
         >
           Launch
         </Button>
-        <Button
-          variant={ButtonVariant.link}
-          component='a'
-          href='https://patternfly.org'
-          target='_blank'
-        >
+        <Button variant={ButtonVariant.link} component="a" href="https://patternfly.org" target="_blank">
           Learn more
         </Button>
       </>

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/Severity.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/Severity.md
@@ -15,15 +15,16 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import Severity, { SeverityType } from '@patternfly/react-component-groups/dist/dynamic/Severity';
+import { FunctionComponent } from 'react'
 
 The **severity** component generates an icon with an optional label, which corresponds to a level `minor`, `moderate`, `important` or `critical`. Each level corresponds with a severity level and respective color:
 
-| Severity level | Meaning | Style | 
-| --- | --- | --- | 
-| Level 1 | Minor severity (best case scenario) | Dark grey icon |
-| Level 2 | Moderate severity |  Yellow icon | 
-| Level 3 | Important severity | Orange icon | 
-| Level 4 | Critical severity (worst case scenario) | Red icon | 
+| Severity level | Meaning                                 | Style          |
+| -------------- | --------------------------------------- | -------------- |
+| Level 1        | Minor severity (best case scenario)     | Dark grey icon |
+| Level 2        | Moderate severity                       | Yellow icon    |
+| Level 3        | Important severity                      | Orange icon    |
+| Level 4        | Critical severity (worst case scenario) | Red icon       |
 
 To specify the severity risk level, you can pass a predefined enum or text value into the `severity` property that corresponds to the appropriate severity level.
 
@@ -33,11 +34,12 @@ To add an optional label, add the `label` property to the `<Severity>` component
 
 ### Undefined variant
 
-The default style for the severity component appears when any value besides "none", "low", "medium", "high", or "critical" is passed to `Severity`. 
+The default style for the severity component appears when any value besides "none", "low", "medium", "high", or "critical" is passed to `Severity`.
 
 ```js file="./SeverityUndefinedExample.tsx"
 
 ```
+
 ### None severity
 
 To style no severity, pass "none" or `SeverityType.none` to `severity`.

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityCriticalExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityCriticalExample.tsx
@@ -1,8 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Severity, { SeverityType } from '@patternfly/react-component-groups/dist/dynamic/Severity';
 
-export const BasicExample: React.FunctionComponent = () => (
-
-  <Severity severity={SeverityType.critical} label="Critical" />
-
-);
+export const BasicExample: FunctionComponent = () => <Severity severity={SeverityType.critical} label="Critical" />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityImportantExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityImportantExample.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Severity, { SeverityType } from '@patternfly/react-component-groups/dist/dynamic/Severity';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <Severity severity={SeverityType.important} label="Important" />
-);
+export const BasicExample: FunctionComponent = () => <Severity severity={SeverityType.important} label="Important" />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityMinorExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityMinorExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Severity, { SeverityType } from '@patternfly/react-component-groups/dist/dynamic/Severity';
 
-export const BasicExample: React.FunctionComponent = () => <Severity severity={SeverityType.minor} label="Minor" />;
+export const BasicExample: FunctionComponent = () => <Severity severity={SeverityType.minor} label="Minor" />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityModerateExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityModerateExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Severity, { SeverityType } from '@patternfly/react-component-groups/dist/dynamic/Severity';
 
-export const BasicExample: React.FunctionComponent = () => <Severity severity={SeverityType.moderate} label="Moderate" />;
+export const BasicExample: FunctionComponent = () => <Severity severity={SeverityType.moderate} label="Moderate" />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityNoneExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityNoneExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Severity, { SeverityType } from '@patternfly/react-component-groups/dist/dynamic/Severity';
 
-export const BasicExample: React.FunctionComponent = () => <Severity severity={SeverityType.none} label="None" />;
+export const BasicExample: FunctionComponent = () => <Severity severity={SeverityType.none} label="None" />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityUndefinedExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Severity/SeverityUndefinedExample.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Severity from '@patternfly/react-component-groups/dist/dynamic/Severity';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const BasicExample: React.FunctionComponent = () => <Severity label="Undefined" severity={'an unknown value' as any} />
+export const BasicExample: FunctionComponent = () => (
+  <Severity label="Undefined" severity={'an unknown value' as any} />
+);

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ShortcutGrid/ShortcutExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ShortcutGrid/ShortcutExample.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import Shortcut from '@patternfly/react-component-groups/dist/dynamic/Shortcut';
 
-export const BasicExample: React.FunctionComponent = () => <Shortcut description='Shortcut description' keys={[ 'cmd', 'shift' ]} click/>;
+export const BasicExample: FunctionComponent = () => (
+  <Shortcut description="Shortcut description" keys={[ 'cmd', 'shift' ]} click />
+);

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ShortcutGrid/ShortcutGrid.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ShortcutGrid/ShortcutGrid.md
@@ -10,15 +10,13 @@ id: Shortcut grid
 source: react
 # If you use typescript, the name of the interface to display props for
 # These are found through the sourceProps function provided in patternfly-docs.source.js
-propComponents: [
-    'ShortcutGrid',
-    'Shortcut'
-]
+propComponents: ['ShortcutGrid', 'Shortcut']
 sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/ShortcutGrid/ShortcutGrid.md
 ---
 
 import ShortcutGrid from '@patternfly/react-component-groups/dist/dynamic/ShortcutGrid';
 import Shortcut from '@patternfly/react-component-groups/dist/dynamic/Shortcut';
+import { FunctionComponent } from 'react';
 
 A **shortcut grid** component displays keyboard shortcuts with their description in a grid.
 
@@ -26,7 +24,7 @@ A **shortcut grid** component displays keyboard shortcuts with their description
 
 ### Basic shortcut grid
 
-A basic shortcut grid can be used to display shortcuts available to the user together with their description. 
+A basic shortcut grid can be used to display shortcuts available to the user together with their description.
 
 You can customize displayed shortcuts using `shortcuts` props. For mouse actions with given shortcuts, there are separate props to be enabled. You can customize showing symbols for control keys using `showSymbols`. The component also accepts all properties of the [grid layout](/layouts/grid).
 
@@ -36,12 +34,10 @@ You can customize displayed shortcuts using `shortcuts` props. For mouse actions
 
 ### Single shortcut
 
-Shortcut component can be also used outside of the grid. 
+Shortcut component can be also used outside of the grid.
 
 Appearance of the component can be customized using the `className` property.
 
 ```js file="./ShortcutExample.tsx"
 
 ```
-
-

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/ShortcutGrid/ShortcutGridExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/ShortcutGrid/ShortcutGridExample.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import ShortcutGrid from '@patternfly/react-component-groups/dist/dynamic/ShortcutGrid';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <ShortcutGrid 
-    shortcuts={[ 
-      { description: 'Open new tab', keys: [ 'cmd', 'shift', 't' ] }, 
+export const BasicExample: FunctionComponent = () => (
+  <ShortcutGrid
+    shortcuts={[
+      { description: 'Open new tab', keys: [ 'cmd', 'shift', 't' ] },
       { description: 'Open new page', keys: [ 'opt', 'n' ] },
-      { description: 'Move object', keys: [ 'ctrl' ], drag: true },  
+      { description: 'Move object', keys: [ 'ctrl' ], drag: true }
     ]}
   />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTable.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTable.md
@@ -13,10 +13,12 @@ source: react
 propComponents: ['SkeletonTable', 'SkeletonTableHead', 'SkeletonTableBody']
 sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTable.md
 ---
+
 import { RowSelectVariant, TableVariant, Table } from '@patternfly/react-table';
 import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/SkeletonTable';
 import SkeletonTableHead from '@patternfly/react-component-groups/dist/dynamic/SkeletonTableHead';
 import SkeletonTableBody from '@patternfly/react-component-groups/dist/dynamic/SkeletonTableBody';
+import { FC, ReactNode, useState, useEffect } from 'react';
 
 The **skeleton table** component is used to display placeholder "skeletons" within a table as its contents load.
 
@@ -67,7 +69,6 @@ Custom column headers can be provided by passing an array of strings or `Th` com
 The following example demonstrates the typical behavior of a skeleton table transitioning to a normal table as the data becomes available.
 
 To simulate this loading process, click the "Reload table" button and wait for the data to populate.
-
 
 ```js file="./SkeletonTableLoadingExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableBodyExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableBodyExample.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { FC } from 'react';
 import { Table } from '@patternfly/react-table';
-import SkeletonTableBody from "@patternfly/react-component-groups/dist/dynamic/SkeletonTableBody";
+import SkeletonTableBody from '@patternfly/react-component-groups/dist/dynamic/SkeletonTableBody';
 
-export const SkeletonTableBodyExample: React.FC = () => (
+export const SkeletonTableBodyExample: FC = () => (
   <Table>
     <SkeletonTableBody isSelectable rowsCount={5} columnsCount={2} />
   </Table>

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableCompactExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableCompactExample.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import SkeletonTable from "@patternfly/react-component-groups/dist/dynamic/SkeletonTable";
+import { FC } from 'react';
+import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/SkeletonTable';
 import { TableVariant } from '@patternfly/react-table';
 
-export const SkeletonTableExample: React.FC = () => <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} variant={TableVariant.compact} borders={false} />;
+export const SkeletonTableExample: FC = () => (
+  <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} variant={TableVariant.compact} borders={false} />
+);

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableCustomExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableCustomExample.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import SkeletonTable from "@patternfly/react-component-groups/dist/dynamic/SkeletonTable";
+import { FC } from 'react';
+import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/SkeletonTable';
 import { Th } from '@patternfly/react-table';
 
-export const SkeletonTableExample: React.FC = () => (
+export const SkeletonTableExample: FC = () => (
   <SkeletonTable
     rowsCount={10}
     columns={[

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
-import SkeletonTable from "@patternfly/react-component-groups/dist/dynamic/SkeletonTable";
+import { FC } from 'react';
+import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/SkeletonTable';
 
-export const SkeletonTableExample: React.FC = () => <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} />
+export const SkeletonTableExample: FC = () => <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableExpandableExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableExpandableExample.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
-import SkeletonTable from "@patternfly/react-component-groups/dist/dynamic/SkeletonTable";
+import { FC } from 'react';
+import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/SkeletonTable';
 
-export const SkeletonTableExample: React.FC = () => <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} isExpandable />;
+export const SkeletonTableExample: FC = () => (
+  <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} isExpandable />
+);

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableHeadExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableHeadExample.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { FC } from 'react';
 import { Table } from '@patternfly/react-table';
-import SkeletonTableHead from "@patternfly/react-component-groups/dist/dynamic/SkeletonTableHead";
+import SkeletonTableHead from '@patternfly/react-component-groups/dist/dynamic/SkeletonTableHead';
 
-export const SkeletonTableHeadExample: React.FC = () => (
+export const SkeletonTableHeadExample: FC = () => (
   <Table>
     <SkeletonTableHead columns={[ 'First', 'Second' ]} />
   </Table>

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableLoadingExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableLoadingExample.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import SkeletonTable from "@patternfly/react-component-groups/dist/dynamic/SkeletonTable";
+import { FC, ReactNode, useState, useEffect } from 'react';
+import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/SkeletonTable';
 import { Table, Tbody, Td, Th, Tr, Thead } from '@patternfly/react-table';
 import { Button, Stack, StackItem } from '@patternfly/react-core';
 
@@ -11,8 +11,8 @@ interface Repository {
   lastCommit: string;
 }
 
-export const SkeletonTableExample: React.FC = () => {
-  const [ isLoaded, setIsLoaded ] = React.useState(false);
+export const SkeletonTableExample: FC = () => {
+  const [ isLoaded, setIsLoaded ] = useState(false);
 
   const loadData = () => {
     setIsLoaded(false);
@@ -35,7 +35,7 @@ export const SkeletonTableExample: React.FC = () => {
     lastCommit: 'Last commit'
   };
 
-  const table: React.ReactNode = !isLoaded ? (
+  const table: ReactNode = !isLoaded ? (
     <SkeletonTable
       rowsCount={3}
       columns={[
@@ -71,7 +71,7 @@ export const SkeletonTableExample: React.FC = () => {
     </Table>
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     loadData();
   }, []);
 
@@ -80,9 +80,7 @@ export const SkeletonTableExample: React.FC = () => {
       <Stack hasGutter>
         <StackItem>{table}</StackItem>
         <StackItem>
-          <Button onClick={loadData}>
-            Reload table
-          </Button>
+          <Button onClick={loadData}>Reload table</Button>
         </StackItem>
       </Stack>
     </>

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableSelectableExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/SkeletonTable/SkeletonTableSelectableExample.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import SkeletonTable from "@patternfly/react-component-groups/dist/dynamic/SkeletonTable";
+import { FC } from 'react';
+import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/SkeletonTable';
 import { RowSelectVariant } from '@patternfly/react-table';
 
-export const SkeletonTableExample: React.FC = () => (
+export const SkeletonTableExample: FC = () => (
   <SkeletonTable rowsCount={10} columns={[ 'First', 'Second' ]} isSelectable selectVariant={RowSelectVariant.radio} />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/StaleDataWarning/StaleDataWarning.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/StaleDataWarning/StaleDataWarning.md
@@ -15,14 +15,15 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import StaleDataWarning from '@patternfly/react-component-groups/dist/dynamic/StaleDataWarning';
+import { Fragment, FunctionComponent } from 'react';
 
-A **stale data warning** component displays a warning status when an object is stale and planned for removal. Additional warning details can be displayed as a tooltip or text label. 
+A **stale data warning** component displays a warning status when an object is stale and planned for removal. Additional warning details can be displayed as a tooltip or text label.
 
 ## Examples
 
 ### Basic stale data warning example
 
-A basic stale data warning component displays a warning icon with additional details in a tooltip, including a timeline for data removal. 
+A basic stale data warning component displays a warning icon with additional details in a tooltip, including a timeline for data removal.
 
 ```js file="./StaleDataWarningExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/StaleDataWarning/StaleDataWarningCustomExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/StaleDataWarning/StaleDataWarningCustomExample.tsx
@@ -1,36 +1,34 @@
-import React from 'react';
+import { Fragment, FunctionComponent } from 'react';
 import StaleDataWarning from '@patternfly/react-component-groups/dist/dynamic/StaleDataWarning';
 import { Stack, StackItem } from '@patternfly/react-core';
 
-
-export const CustomizedRenderExample: React.FunctionComponent = () => {
+export const CustomizedRenderExample: FunctionComponent = () => {
   const staleDate = new Date('Sun Jan 26 2020');
   const warningDate = new Date('Mon Feb 15 2025');
   const cullingDate = new Date('Fri Feb 20 2025');
-  return <>
-    <Stack>
-      <StackItem>
-        <StaleDataWarning
-          stale={staleDate}
-          currDate={new Date()}
-          culled={cullingDate}
-          staleWarning={warningDate}
-          render={({ msg }) => (<React.Fragment>{msg}</React.Fragment>)}>
-        </StaleDataWarning>
-      </StackItem>
+  return (
+    <>
+      <Stack>
+        <StackItem>
+          <StaleDataWarning
+            stale={staleDate}
+            currDate={new Date()}
+            culled={cullingDate}
+            staleWarning={warningDate}
+            render={({ msg }) => <Fragment>{msg}</Fragment>}
+          ></StaleDataWarning>
+        </StackItem>
 
-      <StackItem>
-        <StaleDataWarning
-          stale={staleDate}
-          currDate={new Date()}
-          culled={new Date('Fri Feb 07 2024')}
-          staleWarning={new Date('Mon Feb 03 2024')}
-          render={() => (<React.Fragment>This is an error message where the item is overdue</React.Fragment>)}>
-        </StaleDataWarning>
-      </StackItem>
-    </Stack>
-   
-
-    
-  </>
+        <StackItem>
+          <StaleDataWarning
+            stale={staleDate}
+            currDate={new Date()}
+            culled={new Date('Fri Feb 07 2024')}
+            staleWarning={new Date('Mon Feb 03 2024')}
+            render={() => <Fragment>This is an error message where the item is overdue</Fragment>}
+          ></StaleDataWarning>
+        </StackItem>
+      </Stack>
+    </>
+  );
 };

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/StaleDataWarning/StaleDataWarningExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/StaleDataWarning/StaleDataWarningExample.tsx
@@ -1,33 +1,32 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import StaleDataWarning from '@patternfly/react-component-groups/dist/dynamic/StaleDataWarning';
 import { Stack, StackItem } from '@patternfly/react-core';
 
-export const BasicExample: React.FunctionComponent = () => {
+export const BasicExample: FunctionComponent = () => {
   const staleDate = new Date('Sun Jan 26 2020');
   const warningDate = new Date('Mon Feb 15 2025');
   const cullingDate = new Date('Fri Feb 20 2025');
-  return <>
-    <Stack>
-      <StackItem>
-        <StaleDataWarning
-          stale={staleDate}
-          currDate={new Date()}
-          culled={cullingDate}
-          staleWarning={warningDate}>
-        </StaleDataWarning>
-      </StackItem>
+  return (
+    <>
+      <Stack>
+        <StackItem>
+          <StaleDataWarning
+            stale={staleDate}
+            currDate={new Date()}
+            culled={cullingDate}
+            staleWarning={warningDate}
+          ></StaleDataWarning>
+        </StackItem>
 
-      <StackItem>
-        <StaleDataWarning
-          stale={staleDate}
-          currDate={new Date()}
-          culled={new Date('Fri Feb 17 2024')}
-          staleWarning={new Date('Mon Feb 5 2024')}
-        >
-        </StaleDataWarning>
-      </StackItem>
-    </Stack>
-    
-    
-  </>
+        <StackItem>
+          <StaleDataWarning
+            stale={staleDate}
+            currDate={new Date()}
+            culled={new Date('Fri Feb 17 2024')}
+            staleWarning={new Date('Mon Feb 5 2024')}
+          ></StaleDataWarning>
+        </StackItem>
+      </Stack>
+    </>
+  );
 };

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/IconOnlyStatusExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/IconOnlyStatusExample.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import { Status, IconStatus } from '@patternfly/react-component-groups/dist/dynamic/Status';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <Status iconOnly iconTitle='1 security issue found' status={IconStatus.warning} label='Warning' icon={<ExclamationTriangleIcon/>}/>
+export const BasicExample: FunctionComponent = () => (
+  <Status
+    iconOnly
+    iconTitle="1 security issue found"
+    status={IconStatus.warning}
+    label="Warning"
+    icon={<ExclamationTriangleIcon />}
+  />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/LinkStatusExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/LinkStatusExample.tsx
@@ -1,8 +1,14 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import { IconStatus, Status, StatusVariant } from '@patternfly/react-component-groups/dist/dynamic/Status';
 import { CheckCircleIcon } from '@patternfly/react-icons/';
 
-export const BasicExample: React.FunctionComponent = () => (
-  // eslint-disable-next-line no-console
-  <Status variant={StatusVariant.link} status={IconStatus.success} label='Ready' onClick={() => console.log('Link status clicked')} icon={<CheckCircleIcon/>}/>
+export const BasicExample: FunctionComponent = () => (
+  <Status
+    variant={StatusVariant.link}
+    status={IconStatus.success}
+    label="Ready"
+    // eslint-disable-next-line no-console
+    onClick={() => console.log('Link status clicked')}
+    icon={<CheckCircleIcon />}
+  />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/PopoverStatusExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/PopoverStatusExample.tsx
@@ -1,17 +1,21 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import { IconStatus, Status, StatusVariant } from '@patternfly/react-component-groups/dist/dynamic/Status';
 import { BanIcon } from '@patternfly/react-icons/';
 import { Button, ButtonSize, ButtonVariant } from '@patternfly/react-core';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <Status 
+export const BasicExample: FunctionComponent = () => (
+  <Status
     variant={StatusVariant.popover}
     status={IconStatus.danger}
-    label='Not Ready' 
-    icon={<BanIcon/>}
-    popoverProps={{ 
-      bodyContent: 'Example state description', 
-      footerContent: <Button size={ButtonSize.sm} variant={ButtonVariant.link} isInline>Action</Button> 
+    label="Not Ready"
+    icon={<BanIcon />}
+    popoverProps={{
+      bodyContent: 'Example state description',
+      footerContent: (
+        <Button size={ButtonSize.sm} variant={ButtonVariant.link} isInline>
+          Action
+        </Button>
+      )
     }}
   />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/Status.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/Status.md
@@ -14,14 +14,16 @@ propComponents: ['Status']
 beta: true
 sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/Status.md
 ---
+
 import { BanIcon, CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons/';
 import { Status, StatusVariant, IconStatus } from '@patternfly/react-component-groups/dist/dynamic/Status';
+import { FunctionComponent } from 'react';
 
-The **status** component's purpose is to display status with icon and text to the user. 
+The **status** component's purpose is to display status with icon and text to the user.
 
 ### Basic status
 
-Status component consinsts of an icon configured using `icon` and a message, specified with `label`. 
+Status component consinsts of an icon configured using `icon` and a message, specified with `label`.
 
 ```js file="./StatusExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/StatusDescriptionExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/StatusDescriptionExample.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import { IconStatus, Status } from '@patternfly/react-component-groups/dist/dynamic/Status';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <Status status={IconStatus.warning} label='Warning' description='1 issue found' icon={<ExclamationTriangleIcon/>}/>
+export const BasicExample: FunctionComponent = () => (
+  <Status status={IconStatus.warning} label="Warning" description="1 issue found" icon={<ExclamationTriangleIcon />} />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/StatusExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Status/StatusExample.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import { IconStatus, Status } from '@patternfly/react-component-groups/dist/dynamic/Status';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <Status label='Warning' status={IconStatus.warning} icon={<ExclamationTriangleIcon/>}/>
+export const BasicExample: FunctionComponent = () => (
+  <Status label="Warning" status={IconStatus.warning} icon={<ExclamationTriangleIcon />} />
 );

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/TagCount/TagCount.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/TagCount/TagCount.md
@@ -13,9 +13,11 @@ source: react
 propComponents: ['TagCount']
 sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packages/module/patternfly-docs/content/extensions/component-groups/examples/TagCount/TagCount.md
 ---
-import TagCount from '@patternfly/react-component-groups/dist/dynamic/TagCount';
 
-The **tag count** component generates a tag icon that displays a number, which represents a count value. 
+import TagCount from '@patternfly/react-component-groups/dist/dynamic/TagCount';
+import { FunctionComponent } from 'react';
+
+The **tag count** component generates a tag icon that displays a number, which represents a count value.
 
 ## Examples
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/TagCount/TagCountDisabledExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/TagCount/TagCountDisabledExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import TagCount from '@patternfly/react-component-groups/dist/dynamic/TagCount';
 
-export const TagCountDisabledExample: React.FunctionComponent = () => <TagCount />
+export const TagCountDisabledExample: FunctionComponent = () => <TagCount />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/TagCount/TagCountExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/TagCount/TagCountExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import TagCount from '@patternfly/react-component-groups/dist/dynamic/TagCount';
 
-export const TagCountDisabledExample: React.FunctionComponent = () => <TagCount count={10} />
+export const TagCountDisabledExample: FunctionComponent = () => <TagCount count={10} />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/UnauthorizedAccess/UnauthorizedAccess.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/UnauthorizedAccess/UnauthorizedAccess.md
@@ -8,6 +8,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import UnauthorizedAccess from "@patternfly/react-component-groups/dist/dynamic/UnauthorizedAccess";
+import { FunctionComponent } from 'react';
 
 A **not authorized** component displays an error screen to users when they attempt to view a page that they don't have permission to access.
 
@@ -15,7 +16,7 @@ A **not authorized** component displays an error screen to users when they attem
 
 ### Basic unauthorized access
 
-A basic not authorized component displays a title, body text, and custom actions. 
+A basic not authorized component displays a title, body text, and custom actions.
 
 ```js file="./UnauthorizedAccessExample.tsx"
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/UnauthorizedAccess/UnauthorizedAccessActionsExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/UnauthorizedAccess/UnauthorizedAccessActionsExample.tsx
@@ -1,12 +1,9 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import { Button } from '@patternfly/react-core';
-import UnauthorizedAccess from "@patternfly/react-component-groups/dist/dynamic/UnauthorizedAccess";
+import UnauthorizedAccess from '@patternfly/react-component-groups/dist/dynamic/UnauthorizedAccess';
 
-export const BasicExample: React.FunctionComponent = () => {
-  const primaryAction = 
-    <Button key="1">
-      Custom primary action
-    </Button>;
+export const BasicExample: FunctionComponent = () => {
+  const primaryAction = <Button key="1">Custom primary action</Button>;
   const secondaryActions = [
     <Button key="2" variant="link">
       Second action
@@ -16,12 +13,12 @@ export const BasicExample: React.FunctionComponent = () => {
     </Button>
   ];
   return (
-    <UnauthorizedAccess 
-      primaryAction={primaryAction} 
+    <UnauthorizedAccess
+      primaryAction={primaryAction}
       secondaryActions={secondaryActions}
-      bodyText="Description text" 
+      bodyText="Description text"
       serviceName="Demo bundle"
       prevPageButtonText="Go to previous page"
     />
   );
-}
+};

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/UnauthorizedAccess/UnauthorizedAccessExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/UnauthorizedAccess/UnauthorizedAccessExample.tsx
@@ -1,10 +1,6 @@
-import React from 'react';
-import UnauthorizedAccess from "@patternfly/react-component-groups/dist/dynamic/UnauthorizedAccess";
+import { FunctionComponent } from 'react';
+import UnauthorizedAccess from '@patternfly/react-component-groups/dist/dynamic/UnauthorizedAccess';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <UnauthorizedAccess 
-    bodyText="Description text" 
-    serviceName="Demo bundle"
-  />
+export const BasicExample: FunctionComponent = () => (
+  <UnauthorizedAccess bodyText="Description text" serviceName="Demo bundle" />
 );
-

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Unavailable/UnavailableContent.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Unavailable/UnavailableContent.md
@@ -15,6 +15,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import UnavailableContent from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent';
+import { FunctionComponent } from 'react';
 
 An **unavailable content** component displays a screen to users when they attempt to view a page that is currently unavailable to view.
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/Unavailable/UnavailableContentExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/Unavailable/UnavailableContentExample.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
+import { FunctionComponent } from 'react';
 import UnavailableContent from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent';
 
-export const BasicExample: React.FunctionComponent = () => (
-  <UnavailableContent statusPageUrl="https://www.patternfly.org"/>
-);
+export const BasicExample: FunctionComponent = () => <UnavailableContent statusPageUrl="https://www.patternfly.org" />;

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModal.md
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModal.md
@@ -15,6 +15,7 @@ sourceLink: https://github.com/patternfly/react-component-groups/blob/main/packa
 ---
 
 import WarningModal from '@patternfly/react-component-groups/dist/dynamic/WarningModal';
+import { FunctionComponent, useState } from 'react';
 
 A **warning modal** component displays a modal when a user tries to perform a risky action, which asks them to confirm or cancel the action.
 
@@ -22,9 +23,9 @@ A **warning modal** component displays a modal when a user tries to perform a ri
 
 ### Basic warning modal
 
-A basic warning modal is triggered when a user tries to perform an action that is deemed risky. 
+A basic warning modal is triggered when a user tries to perform an action that is deemed risky.
 
-You can customize the contents of the modal to fit your use cases. To adjust the text in the modal, pass your desired title to `title` and your message to the `<WarningModal>` component. To customize the action buttons in the modal, use `onConfirm` and `onClose`. 
+You can customize the contents of the modal to fit your use cases. To adjust the text in the modal, pass your desired title to `title` and your message to the `<WarningModal>` component. To customize the action buttons in the modal, use `onConfirm` and `onClose`.
 
 For further customization, you can utilize all properties of the [modal component](/components/modal), with the exception of `ref`.
 
@@ -40,7 +41,6 @@ You can apply custom variant to a warning modal's confirmation button.
 
 ```
 
-
 ### Warning modal with a checkbox
 
 To confirm that a user wishes to initiate a selected action, you can add a checkbox to a warning modal.
@@ -48,7 +48,6 @@ To confirm that a user wishes to initiate a selected action, you can add a check
 ```js file="./WarningModalCheckboxExample.tsx"
 
 ```
-
 
 ### Warning modal with a text confirmation
 

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalCheckboxExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalCheckboxExample.tsx
@@ -1,21 +1,23 @@
-import React from 'react';
+import { FunctionComponent, useState } from 'react';
 import WarningModal from '@patternfly/react-component-groups/dist/dynamic/WarningModal';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 
-export const BasicExample: React.FunctionComponent = () => {
-  const [ isOpen, setIsOpen ] = React.useState(false);
-  return <>
-    <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-    <WarningModal
-      isOpen={isOpen}
-      title='Unsaved changes'
-      onClose={() => setIsOpen(false)}
-      onConfirm={() => setIsOpen(false)}
-      withCheckbox
-      checkboxLabel='Are you sure?'
-      confirmButtonVariant={ButtonVariant.danger}
-    >
-      Your page contains unsaved changes. Do you want to leave?
-    </WarningModal>
-  </>
+export const BasicExample: FunctionComponent = () => {
+  const [ isOpen, setIsOpen ] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+      <WarningModal
+        isOpen={isOpen}
+        title="Unsaved changes"
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+        withCheckbox
+        checkboxLabel="Are you sure?"
+        confirmButtonVariant={ButtonVariant.danger}
+      >
+        Your page contains unsaved changes. Do you want to leave?
+      </WarningModal>
+    </>
+  );
 };

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalDangerExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalDangerExample.tsx
@@ -1,18 +1,21 @@
-import React from 'react';
+import { FunctionComponent, useState } from 'react';
 import WarningModal from '@patternfly/react-component-groups/dist/dynamic/WarningModal';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 
-export const BasicExample: React.FunctionComponent = () => {
-  const [ isOpen, setIsOpen ] = React.useState(false);
-  return <>
-    <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-    <WarningModal
-      isOpen={isOpen}
-      title='Unsaved changes'
-      confirmButtonVariant={ButtonVariant.danger}
-      onClose={() => setIsOpen(false)}
-      onConfirm={() => setIsOpen(false)}>
-      Your page contains unsaved changes. Do you want to leave?
-    </WarningModal>
-  </>
+export const BasicExample: FunctionComponent = () => {
+  const [ isOpen, setIsOpen ] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+      <WarningModal
+        isOpen={isOpen}
+        title="Unsaved changes"
+        confirmButtonVariant={ButtonVariant.danger}
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+      >
+        Your page contains unsaved changes. Do you want to leave?
+      </WarningModal>
+    </>
+  );
 };

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalExample.tsx
@@ -1,19 +1,22 @@
-import React from 'react';
+import { FunctionComponent, useState } from 'react';
 import WarningModal from '@patternfly/react-component-groups/dist/dynamic/WarningModal';
 import { Button } from '@patternfly/react-core';
 
-export const BasicExample: React.FunctionComponent = () => {
-  const [ isOpen, setIsOpen ] = React.useState(false);
-  return <>
-    <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-    <WarningModal
-      isOpen={isOpen}
-      title='Unsaved changes'
-      confirmButtonLabel='Yes'
-      cancelButtonLabel='No'
-      onClose={() => setIsOpen(false)}
-      onConfirm={() => setIsOpen(false)}>
-      Your page contains unsaved changes. Do you want to leave?
-    </WarningModal>
-  </>
+export const BasicExample: FunctionComponent = () => {
+  const [ isOpen, setIsOpen ] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+      <WarningModal
+        isOpen={isOpen}
+        title="Unsaved changes"
+        confirmButtonLabel="Yes"
+        cancelButtonLabel="No"
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+      >
+        Your page contains unsaved changes. Do you want to leave?
+      </WarningModal>
+    </>
+  );
 };

--- a/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalTextConfirmationExample.tsx
+++ b/packages/module/patternfly-docs/content/extensions/component-groups/examples/WarningModal/WarningModalTextConfirmationExample.tsx
@@ -1,21 +1,24 @@
-import React from 'react';
+import { FunctionComponent, useState } from 'react';
 import WarningModal from '@patternfly/react-component-groups/dist/dynamic/WarningModal';
 import { Button } from '@patternfly/react-core';
 
-export const BasicExample: React.FunctionComponent = () => {
-  const [ isOpen, setIsOpen ] = React.useState(false);
-  return <>
-    <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-    <WarningModal
-      isOpen={isOpen}
-      title='Delete item?'
-      confirmButtonLabel='Yes'
-      cancelButtonLabel='No'
-      onClose={() => setIsOpen(false)}
-      onConfirm={() => setIsOpen(false)}
-      confirmationInputProps={{ type: 'text', isRequired: true }}
-      confirmationText='Item1'>
-      The item will be deleted.
-    </WarningModal>
-  </>
+export const BasicExample: FunctionComponent = () => {
+  const [ isOpen, setIsOpen ] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+      <WarningModal
+        isOpen={isOpen}
+        title="Delete item?"
+        confirmButtonLabel="Yes"
+        cancelButtonLabel="No"
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+        confirmationInputProps={{ type: 'text', isRequired: true }}
+        confirmationText="Item1"
+      >
+        The item will be deleted.
+      </WarningModal>
+    </>
+  );
 };

--- a/packages/module/patternfly-docs/pages/index.js
+++ b/packages/module/patternfly-docs/pages/index.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import { Title, PageSection } from '@patternfly/react-core';
 

--- a/packages/module/src/Ansible/Ansible.test.tsx
+++ b/packages/module/src/Ansible/Ansible.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import Ansible from './Ansible';
 

--- a/packages/module/src/Ansible/Ansible.tsx
+++ b/packages/module/src/Ansible/Ansible.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { FunctionComponent, CSSProperties } from 'react';
+import { Fragment } from 'react';
 import clsx from 'clsx';
 import { createUseStyles } from 'react-jss';
 
@@ -51,7 +52,7 @@ const useStyles = createUseStyles({
   }
 })
 
-const Ansible: React.FunctionComponent<AnsibleProps> = ({ isSupported = true, isRHAAP, className, ouiaId = "Ansible-icon", ...props }: AnsibleProps) => {
+const Ansible: FunctionComponent<AnsibleProps> = ({ isSupported = true, isRHAAP, className, ouiaId = "Ansible-icon", ...props }: AnsibleProps) => {
   const classes = useStyles();
   const ansibleLogoClass = clsx(
     classes.ansible,
@@ -61,7 +62,7 @@ const Ansible: React.FunctionComponent<AnsibleProps> = ({ isSupported = true, is
   );
 
   const unsupportedSlash = (
-    <React.Fragment>
+    <Fragment>
       <rect
         x="1245.1"
         y="272.4"
@@ -88,11 +89,11 @@ const Ansible: React.FunctionComponent<AnsibleProps> = ({ isSupported = true, is
         width="563.7"
         height="221.5"
       />
-    </React.Fragment>
+    </Fragment>
   );
 
   return (
-    <React.Fragment>
+    (<Fragment>
       {isRHAAP ? (
         <i title="Red Hat Ansible Automation Platform" data-ouia-component-id={ouiaId} {...props}>
           {RHAAPTechnologyIcon}
@@ -104,7 +105,7 @@ const Ansible: React.FunctionComponent<AnsibleProps> = ({ isSupported = true, is
             x="0px"
             y="0px"
             viewBox="0 0 2032 2027.2"
-            style={{ enableBackground: 'new 0 0 2032 2027.2' } as React.CSSProperties}
+            style={{ enableBackground: 'new 0 0 2032 2027.2' } as CSSProperties}
           >
             <path
               className="st0"
@@ -117,7 +118,7 @@ const Ansible: React.FunctionComponent<AnsibleProps> = ({ isSupported = true, is
           </svg>
         </i>
       ) }
-    </React.Fragment>
+    </Fragment>)
   );
 };
 

--- a/packages/module/src/BulkSelect/BulkSelect.test.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import BulkSelect from './BulkSelect';
 

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import type { FC, Ref } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Dropdown,
   DropdownItem,
@@ -45,7 +46,7 @@ export interface BulkSelectProps extends Omit<DropdownProps, 'toggle' | 'onSelec
   menuToggleCheckboxProps?: Omit<MenuToggleCheckboxProps, 'onChange' | 'isChecked' | 'instance' | 'ref'>;
 }
 
-export const BulkSelect: React.FC<BulkSelectProps> = ({
+export const BulkSelect: FC<BulkSelectProps> = ({
   isDataPaginated = true,
   canSelectAll,
   pageSelected,
@@ -87,7 +88,7 @@ export const BulkSelect: React.FC<BulkSelectProps> = ({
   const onToggleClick = () => setOpen(!isOpen);
 
   return (
-    <Dropdown
+    (<Dropdown
       shouldFocusToggleOnSelect
       ouiaId={`${ouiaId}-dropdown`}
       onSelect={(_e, value) => {
@@ -96,7 +97,7 @@ export const BulkSelect: React.FC<BulkSelectProps> = ({
       }}
       isOpen={isOpen}
       onOpenChange={(isOpen: boolean) => setOpen(isOpen)}
-      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+      toggle={(toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
           ref={toggleRef}
           isExpanded={isOpen}
@@ -129,7 +130,7 @@ export const BulkSelect: React.FC<BulkSelectProps> = ({
       {...props}
     >
       <DropdownList>{splitButtonDropdownItems}</DropdownList>
-    </Dropdown>
+    </Dropdown>)
   );
 };
 

--- a/packages/module/src/CloseButton/CloseButton.tsx
+++ b/packages/module/src/CloseButton/CloseButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import { Button, ButtonProps, ButtonVariant } from '@patternfly/react-core';
 import { CloseIcon } from '@patternfly/react-icons';
 import { createUseStyles } from 'react-jss';
@@ -17,7 +17,7 @@ export interface CloseButtonProps extends ButtonProps {
   dataTestID?: string;
 };
 
-export const CloseButton: React.FunctionComponent<CloseButtonProps> = ({
+export const CloseButton: FunctionComponent<CloseButtonProps> = ({
   className,
   dataTestID,
   onClick,

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import '@testing-library/jest-dom'
 import { render, screen, fireEvent } from '@testing-library/react';
 import ColumnManagementModal, { ColumnManagementModalColumn } from './ColumnManagementModal';

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
+import { useState } from 'react';
 import {
   Button,
   Content,
@@ -17,36 +18,36 @@ import { ModalProps, Modal, ModalVariant } from '@patternfly/react-core/deprecat
 
 export interface ColumnManagementModalColumn {
   /** Internal identifier of a column by which table displayed columns are filtered. */
-  key: string,
+  key: string;
   /** The actual display name of the column possibly with a tooltip or icon. */
-  title: React.ReactNode,
+  title: React.ReactNode;
   /** If user changes checkboxes, the component will send back column array with this property altered. */
-  isShown?: boolean,
+  isShown?: boolean;
   /** Set to false if the column should be hidden initially */
-  isShownByDefault: boolean,
+  isShownByDefault: boolean;
   /** The checkbox will be disabled, this is applicable to columns which should not be toggleable by user */
-  isUntoggleable?: boolean
+  isUntoggleable?: boolean;
 }
 
 /** extends ModalProps */
 export interface ColumnManagementModalProps extends Omit<ModalProps, 'ref' | 'children'> {
   /** Flag to show the modal */
-  isOpen?: boolean,
+  isOpen?: boolean;
   /** Invoked when modal visibility is changed */
-  onClose?: (event: KeyboardEvent | React.MouseEvent) => void,
+  onClose?: (event: KeyboardEvent | React.MouseEvent) => void;
   /** Current column state */
-  appliedColumns: ColumnManagementModalColumn[],
+  appliedColumns: ColumnManagementModalColumn[];
   /** Invoked with new column state after save button is clicked */
-  applyColumns: (newColumns: ColumnManagementModalColumn[]) => void,
+  applyColumns: (newColumns: ColumnManagementModalColumn[]) => void;
   /* Modal description text */
-  description?: string,
+  description?: string;
   /* Modal title text */
-  title?: string,
+  title?: string;
   /** Custom OUIA ID */
-  ouiaId?: string | number,
-};
+  ouiaId?: string | number;
+}
 
-const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps> = (
+const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = (
   { title = 'Manage columns',
     description = 'Selected categories will be displayed in the table.',
     isOpen = false,
@@ -56,7 +57,7 @@ const ColumnManagementModal: React.FunctionComponent<ColumnManagementModalProps>
     ouiaId = 'ColumnManagementModal',
     ...props }: ColumnManagementModalProps) => {
 
-  const [ currentColumns, setCurrentColumns ] = React.useState(
+  const [ currentColumns, setCurrentColumns ] = useState(
     appliedColumns.map(column => ({ ...column, isShown: column.isShown ?? column.isShownByDefault }))
   );
 

--- a/packages/module/src/ContentHeader/ContentHeader.tsx
+++ b/packages/module/src/ContentHeader/ContentHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { PropsWithChildren, FunctionComponent } from 'react';
 import {
   Flex,
   FlexItem,
@@ -47,7 +47,7 @@ const useStyles = createUseStyles({
   }
 });
 
-export const ContentHeader: React.FunctionComponent<React.PropsWithChildren<ContentHeaderProps>> = ({
+export const ContentHeader: FunctionComponent<PropsWithChildren<ContentHeaderProps>> = ({
   title,
   subtitle = null,
   linkProps,

--- a/packages/module/src/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/module/src/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import ErrorBoundary from './ErrorBoundary';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/module/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/module/src/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
+import { Component } from 'react';
 import { ExpandableSection, Title } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
 import ErrorState from '../ErrorState';
@@ -49,7 +50,7 @@ interface ErrorPageProps extends ErrorBoundaryProps {
   classes: Record<string | number | symbol, string>;
 }
 
-export const ErrorBoundary: React.FunctionComponent<ErrorBoundaryProps> = ({
+export const ErrorBoundary: FunctionComponent<ErrorBoundaryProps> = ({
   headerTitleHeadingLevel = "h1",
   errorTitleHeadingLevel = "h2",
   ...props
@@ -66,7 +67,7 @@ export const ErrorBoundary: React.FunctionComponent<ErrorBoundaryProps> = ({
 }
 
 // As of time of writing, React only supports error boundaries in class components
-class ErrorBoundaryContent extends React.Component<ErrorPageProps, ErrorBoundaryState> {
+class ErrorBoundaryContent extends Component<ErrorPageProps, ErrorBoundaryState> {
   constructor(props: Readonly<ErrorPageProps>) {
     super(props);
     this.state = {
@@ -128,6 +129,6 @@ class ErrorBoundaryContent extends React.Component<ErrorPageProps, ErrorBoundary
 
     return props.children;
   }
-};
+}
 
 export default ErrorBoundary;

--- a/packages/module/src/ErrorStack/ErrorStack.tsx
+++ b/packages/module/src/ErrorStack/ErrorStack.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 import clsx from 'clsx';
 import { Content } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
@@ -23,7 +23,7 @@ const useStyles = createUseStyles({
   },
 })
 
-export const ErrorStack: React.FunctionComponent<ErrorStackProps> = ({ error, className, ...props }) => {
+export const ErrorStack: FunctionComponent<ErrorStackProps> = ({ error, className, ...props }) => {
   const classes = useStyles();
 
   if (error.stack) {

--- a/packages/module/src/ErrorState/ErrorState.test.tsx
+++ b/packages/module/src/ErrorState/ErrorState.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import ErrorState from './ErrorState';
 import { render, screen } from '@testing-library/react';
 import { Button } from '@patternfly/react-core';

--- a/packages/module/src/ErrorState/ErrorState.tsx
+++ b/packages/module/src/ErrorState/ErrorState.tsx
@@ -10,7 +10,7 @@ import {
   StackItem, 
 } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss'
-import React from 'react';
+import type { FunctionComponent } from 'react';
 
 const useStyles = createUseStyles({
   errorDescription: {
@@ -34,7 +34,7 @@ export interface ErrorStateProps extends Omit<EmptyStateProps, 'children' | 'tit
   status?: 'danger' | 'warning' | 'success' | 'info' | 'custom' | 'none';
 }
 
-const ErrorState: React.FunctionComponent<ErrorStateProps> = ({ 
+const ErrorState: FunctionComponent<ErrorStateProps> = ({ 
   titleText = 'Something went wrong', 
   bodyText, 
   defaultBodyText, 

--- a/packages/module/src/LogSnippet/LogSnippet.test.tsx
+++ b/packages/module/src/LogSnippet/LogSnippet.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import LogSnippet from './LogSnippet';
 

--- a/packages/module/src/LogSnippet/LogSnippet.tsx
+++ b/packages/module/src/LogSnippet/LogSnippet.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 import { Alert, AlertVariant, CodeBlock, CodeBlockCode, Flex, FlexItem, FlexProps } from '@patternfly/react-core';
 
 /** extends FlexProps */
@@ -13,7 +13,7 @@ export interface LogSnippetProps extends FlexProps {
   ouiaId?: string | number;
 }
 
-export const LogSnippet: React.FunctionComponent<LogSnippetProps> = ({ logSnippet, message, variant = AlertVariant.danger, ouiaId = "LogSnippet", ...props }: LogSnippetProps) => (
+export const LogSnippet: FunctionComponent<LogSnippetProps> = ({ logSnippet, message, variant = AlertVariant.danger, ouiaId = "LogSnippet", ...props }: LogSnippetProps) => (
   <Flex direction={{ default: 'column' }} data-ouia-component-id={ouiaId} {...props}>
     <FlexItem>
       { typeof message === 'string' ? <Alert isInline isPlain title={message} variant={variant} data-ouia-component-id={`${ouiaId}-message`} /> : message }

--- a/packages/module/src/Maintenance/Maintenance.tsx
+++ b/packages/module/src/Maintenance/Maintenance.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import { Button, EmptyState, EmptyStateBody, EmptyStateFooter, EmptyStateProps, EmptyStateStatus, EmptyStateVariant } from '@patternfly/react-core';
 import { HourglassHalfIcon } from '@patternfly/react-icons';
 
@@ -25,7 +25,7 @@ export interface MaintenanceProps extends Omit<EmptyStateProps, 'children' | 'ti
     /** Custom OUIA ID */
     ouiaId?: string | number;  }
 
-const Maintenance: React.FunctionComponent<MaintenanceProps> = ({ 
+const Maintenance: FunctionComponent<MaintenanceProps> = ({ 
   titleText = 'Maintenance in progress',
   defaultBodyText = 'We are currently undergoing scheduled maintenance. Thank you for understanding.',
   startTime,

--- a/packages/module/src/MissingPage/MissingPage.test.tsx
+++ b/packages/module/src/MissingPage/MissingPage.test.tsx
@@ -1,5 +1,4 @@
 import MissingPage from './MissingPage';
-import React from 'react';
 import { render } from '@testing-library/react';
 
 describe('MissingPage component', () => {

--- a/packages/module/src/MissingPage/MissingPage.tsx
+++ b/packages/module/src/MissingPage/MissingPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import { Button, EmptyState, EmptyStateBody, EmptyStateFooter, EmptyStateProps, EmptyStateVariant } from '@patternfly/react-core';
 import NotFoundIcon from '../NotFoundIcon';
 
@@ -16,7 +16,7 @@ export interface MissingPageProps extends Omit<EmptyStateProps, 'children' | 'ti
   ouiaId?: string | number;
 }
 
-export const MissingPage: React.FunctionComponent<MissingPageProps> = ({
+export const MissingPage: FunctionComponent<MissingPageProps> = ({
   toHomePageUrl = window.location.origin,
   toHomePageText = 'Return to homepage',
   titleText = 'We lost that page',

--- a/packages/module/src/MultiContentCard/MultiContentCard.test.tsx
+++ b/packages/module/src/MultiContentCard/MultiContentCard.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { Ref } from 'react';
 import { screen, render } from '@testing-library/react';
 import { Button, Card, CardHeader, CardBody, Content, ContentVariants, Icon, List, ListItem, CardFooter, Dropdown, MenuToggle, DropdownList, DropdownItem, MenuToggleElement } from '@patternfly/react-core';
 import { ArrowRightIcon, BellIcon, CogIcon, EllipsisVIcon, LockIcon } from '@patternfly/react-icons';
@@ -138,7 +138,7 @@ describe('MultiContentCard component', () => {
             isOpen
             onSelect={() => null}
             onOpenChange={() => null}
-            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            toggle={(toggleRef: Ref<MenuToggleElement>) => (
               <MenuToggle
                 ref={toggleRef}
                 aria-label="kebab dropdown toggle"

--- a/packages/module/src/MultiContentCard/MultiContentCard.tsx
+++ b/packages/module/src/MultiContentCard/MultiContentCard.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ReactElement, FunctionComponent } from 'react';
+import { isValidElement, useState, Fragment } from 'react';
 import {
   Card,
   CardExpandableContent,
@@ -48,8 +49,8 @@ export interface MultiContentCardProps extends Omit<CardProps, 'children' | 'tit
 }
 
 export const isCardWithProps = (
-  card: React.ReactElement | MutliContentCardProps
-): card is MutliContentCardProps => !!card && !React.isValidElement(card);
+  card: ReactElement | MutliContentCardProps
+): card is MutliContentCardProps => !!card && !isValidElement(card);
 
 const useStyles = createUseStyles({
   cardTitle: {
@@ -57,7 +58,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const MultiContentCard: React.FunctionComponent<MultiContentCardProps> = ({
+const MultiContentCard: FunctionComponent<MultiContentCardProps> = ({
   cards = [],
   isToggleRightAligned = false,
   actions,
@@ -69,16 +70,16 @@ const MultiContentCard: React.FunctionComponent<MultiContentCardProps> = ({
   ouiaId = 'MultiContentCard',
   ...props
 }: MultiContentCardProps) => {
-  const [ isExpanded, setIsExpanded ] = React.useState(defaultExpanded);
+  const [ isExpanded, setIsExpanded ] = useState(defaultExpanded);
   const classes = useStyles();
   const onExpand = () => {
     setIsExpanded(!isExpanded);
   };
   
-  const renderCards = (cards: (React.ReactElement | MutliContentCardProps)[], withDividers?: boolean) =>  (
+  const renderCards = (cards: (ReactElement | MutliContentCardProps)[], withDividers?: boolean) =>  (
     <Flex alignSelf={{ default: 'alignSelfStretch' }} alignItems={{ default: 'alignItemsStretch' }}>
       {cards.map((card, index) => (
-        <React.Fragment key={`card-${index}`}>
+        <Fragment key={`card-${index}`}>
           {index > 0 && isCardWithProps(card) && card.dividerVariant === MultiContentCardDividerVariant.left && (
             <Divider 
               orientation={{ md: 'vertical' }} 
@@ -94,7 +95,7 @@ const MultiContentCard: React.FunctionComponent<MultiContentCardProps> = ({
               inset={{ default: 'inset3xl' }}
             />
           )}
-        </React.Fragment>
+        </Fragment>
       ))} 
     </Flex>
   );

--- a/packages/module/src/NotFoundIcon/NotFoundIcon.tsx
+++ b/packages/module/src/NotFoundIcon/NotFoundIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import { createUseStyles } from 'react-jss';
 import { PathMissingIcon } from '@patternfly/react-icons';
 
@@ -7,7 +7,7 @@ const useStyles = createUseStyles({
 });
 
 
-export const NotFoundIcon: React.FunctionComponent = (props) => (
+export const NotFoundIcon: FunctionComponent = (props) => (
   <PathMissingIcon
     {...props}
     className={useStyles().notFoundIcon}

--- a/packages/module/src/PageHeader/PageHeader.test.tsx
+++ b/packages/module/src/PageHeader/PageHeader.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import PageHeader from './PageHeader';
 

--- a/packages/module/src/PageHeader/PageHeader.tsx
+++ b/packages/module/src/PageHeader/PageHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import {
   Button,
   ButtonProps,
@@ -52,7 +52,7 @@ const useStyles = createUseStyles({
   }
 });
 
-export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
+export const PageHeader: FunctionComponent<PageHeaderProps> = ({
   title,
   subtitle,
   linkProps,

--- a/packages/module/src/ResponsiveAction/ResponsiveAction.tsx
+++ b/packages/module/src/ResponsiveAction/ResponsiveAction.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import { ButtonProps } from '@patternfly/react-core';
 
 /** extends ButtonProps */
@@ -14,6 +14,6 @@ export interface ResponsiveActionProps extends ButtonProps {
 };
 
 // This component is only used declaratively - rendering ishandled by ResponsiveActions
-export const ResponsiveAction: React.FunctionComponent<ResponsiveActionProps> = (_props: ResponsiveActionProps) => <div/>;
+export const ResponsiveAction: FunctionComponent<ResponsiveActionProps> = (_props: ResponsiveActionProps) => <div/>;
 
 export default ResponsiveAction;

--- a/packages/module/src/ResponsiveActions/ResponsiveActions.test.tsx
+++ b/packages/module/src/ResponsiveActions/ResponsiveActions.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import ResponsiveActions from './ResponsiveActions';
 import ResponsiveAction from '../ResponsiveAction';

--- a/packages/module/src/ResponsiveActions/ResponsiveActions.tsx
+++ b/packages/module/src/ResponsiveActions/ResponsiveActions.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { ReactNode, FunctionComponent } from 'react';
+import { Children, isValidElement, useState } from 'react';
 import { Button, Dropdown, DropdownList, MenuToggle, OverflowMenu, OverflowMenuContent, OverflowMenuControl, OverflowMenuDropdownItem, OverflowMenuGroup, OverflowMenuItem, OverflowMenuProps } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import { ResponsiveActionProps } from '../ResponsiveAction';
@@ -13,16 +14,16 @@ export interface ResponsiveActionsProps extends Omit<OverflowMenuProps, 'ref' | 
   children: React.ReactNode;
 }
 
-export const ResponsiveActions: React.FunctionComponent<ResponsiveActionsProps> = ({ ouiaId = 'ResponsiveActions', breakpoint = 'lg', children, ...props }: ResponsiveActionsProps) => {
+export const ResponsiveActions: FunctionComponent<ResponsiveActionsProps> = ({ ouiaId = 'ResponsiveActions', breakpoint = 'lg', children, ...props }: ResponsiveActionsProps) => {
   const [ isOpen, setIsOpen ] = useState(false);
 
   // separate persistent, pinned and collapsed actions
-  const persistentActions: React.ReactNode[] = [];
-  const pinnedActions: React.ReactNode[] = [];
-  const dropdownItems: React.ReactNode[] = [];
+  const persistentActions: ReactNode[] = [];
+  const pinnedActions: ReactNode[] = [];
+  const dropdownItems: ReactNode[] = [];
 
-  React.Children.forEach(children, (child, index) => {
-    if (React.isValidElement<ResponsiveActionProps>(child)) {
+  Children.forEach(children, (child, index) => {
+    if (isValidElement<ResponsiveActionProps>(child)) {
       const { isPersistent, isPinned, key = index, children, onClick, ...actionProps } = child.props;
 
       if (isPersistent || isPinned) {

--- a/packages/module/src/ServiceCard/ServiceCard.test.tsx
+++ b/packages/module/src/ServiceCard/ServiceCard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import ServiceCard from './ServiceCard';
 

--- a/packages/module/src/ServiceCard/ServiceCard.tsx
+++ b/packages/module/src/ServiceCard/ServiceCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import { Card, CardBody, CardFooter, CardHeader, CardProps, Content, ContentVariants, Flex, FlexItem } from '@patternfly/react-core';
 import { HelperText } from '@patternfly/react-core/dist/dynamic/components/HelperText';
 import { HelperTextItem } from '@patternfly/react-core/dist/dynamic/components/HelperText';
@@ -37,7 +37,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const ServiceCard: React.FunctionComponent<ServiceCardProps> = ({
+const ServiceCard: FunctionComponent<ServiceCardProps> = ({
   title,
   subtitle,
   description,

--- a/packages/module/src/Severity/Severity.test.tsx
+++ b/packages/module/src/Severity/Severity.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import Severity, { SeverityType } from './Severity';
 

--- a/packages/module/src/Severity/Severity.tsx
+++ b/packages/module/src/Severity/Severity.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import type { FunctionComponent } from 'react';
+import { Fragment, useMemo } from 'react';
 import {
   SeverityCriticalIcon,
   SeverityImportantIcon,
@@ -50,7 +51,7 @@ export interface SeverityProps extends React.DetailedHTMLProps<React.HTMLAttribu
   ouiaId?: string | number;
 }
 
-export const Severity: React.FunctionComponent<SeverityProps> = ({
+export const Severity: FunctionComponent<SeverityProps> = ({
   severity,
   label,
   labelHidden,
@@ -64,7 +65,7 @@ export const Severity: React.FunctionComponent<SeverityProps> = ({
   const severityVariant = useMemo(() => severityLevels(severity), [ severity ]);
 
   return (
-    <React.Fragment>
+    (<Fragment>
       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
         <FlexItem>
           {/* eslint-disable-next-line react/no-unknown-property */}
@@ -76,7 +77,7 @@ export const Severity: React.FunctionComponent<SeverityProps> = ({
           {!labelHidden && label}
         </FlexItem>
       </Flex>
-    </React.Fragment>
+    </Fragment>)
   );
 };
 

--- a/packages/module/src/Shortcut/Shortcut.test.tsx
+++ b/packages/module/src/Shortcut/Shortcut.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import Shortcut from './Shortcut';
 

--- a/packages/module/src/Shortcut/Shortcut.tsx
+++ b/packages/module/src/Shortcut/Shortcut.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 import { MouseIcon } from '@patternfly/react-icons';
 import { Label } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
@@ -45,7 +45,7 @@ const useStyles = createUseStyles({
   }
 })
 
-const Shortcut: React.FunctionComponent<ShortcutProps> = ({
+const Shortcut: FunctionComponent<ShortcutProps> = ({
   keys = [],
   description = null,
   showSymbols = true,

--- a/packages/module/src/ShortcutGrid/ShortcutGrid.test.tsx
+++ b/packages/module/src/ShortcutGrid/ShortcutGrid.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import ShortcutGrid from './ShortcutGrid';
 

--- a/packages/module/src/ShortcutGrid/ShortcutGrid.tsx
+++ b/packages/module/src/ShortcutGrid/ShortcutGrid.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
+import { Fragment } from 'react';
 import { createUseStyles } from 'react-jss';
 import Shortcut, { ShortcutProps } from '../Shortcut/Shortcut';
 import { Grid, GridItem, GridItemProps, GridProps } from '@patternfly/react-core';
@@ -20,21 +21,22 @@ const useStyles = createUseStyles({
   }
 })
 
-const ShortcutGrid: React.FunctionComponent<ShortcutGridProps> = ({ shortcuts, gridItemProps, ouiaId = 'ShortcutGrid', ...props }: ShortcutGridProps) => {
+const ShortcutGrid: FunctionComponent<ShortcutGridProps> = ({ shortcuts, gridItemProps, ouiaId = 'ShortcutGrid', ...props }: ShortcutGridProps) => {
   const classes = useStyles();
   return (
-    <Grid span={6} hasGutter key="grid" data-ouia-component-id={ouiaId} {...props}>
+    (<Grid span={6} hasGutter key="grid" data-ouia-component-id={ouiaId} {...props}>
       {shortcuts.map((shortcut, index) => {
         const { description, ...props } = shortcut;
-        return(
-          <React.Fragment key={index}>
+        return (
+          (<Fragment key={index}>
             <GridItem className={classes.shortcutGridItem} data-ouia-component-id={`${ouiaId}-item-${index}`} {...gridItemProps}>
               <Shortcut {...props}/>
             </GridItem>
             <GridItem data-ouia-component-id={`${ouiaId}-item-description-${index}`}>{description}</GridItem>
-          </React.Fragment>
-        )})}
+          </Fragment>)
+        );})}
     </Grid>)
+  );
 }
 
 export default ShortcutGrid;

--- a/packages/module/src/SkeletonTable/SkeletonTable.test.tsx
+++ b/packages/module/src/SkeletonTable/SkeletonTable.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import SkeletonTable from './SkeletonTable';
 

--- a/packages/module/src/SkeletonTable/SkeletonTable.tsx
+++ b/packages/module/src/SkeletonTable/SkeletonTable.tsx
@@ -1,17 +1,13 @@
-import React, { ReactNode } from 'react';
-import {
-  Caption,
-  Table,
-  TableProps,
-  TableVariant,
-  RowSelectVariant,
-  ThProps
-} from '@patternfly/react-table';
+import { FunctionComponent, ReactNode } from 'react';
+import { Caption, Table, TableProps, TableVariant, RowSelectVariant, ThProps } from '@patternfly/react-table';
 import SkeletonTableBody, { SkeletonTableBodyProps } from '../SkeletonTableBody';
 import SkeletonTableHead, { SkeletonTableHeadProps } from '../SkeletonTableHead';
 
 /** extends TableProps */
-export interface SkeletonTableProps extends Omit<TableProps, 'ref'>, Omit<SkeletonTableBodyProps, 'columnsCount'>, SkeletonTableHeadProps {
+export interface SkeletonTableProps
+  extends Omit<TableProps, 'ref'>,
+    Omit<SkeletonTableBodyProps, 'columnsCount'>,
+    SkeletonTableHeadProps {
   /** Indicates the table variant */
   variant?: TableVariant;
   /** Flag indicating if the table should have borders */
@@ -34,7 +30,7 @@ export interface SkeletonTableProps extends Omit<TableProps, 'ref'>, Omit<Skelet
   columnsCount?: number;
 }
 
-const SkeletonTable: React.FunctionComponent<SkeletonTableProps> = ({
+const SkeletonTable: FunctionComponent<SkeletonTableProps> = ({
   variant,
   borders = true,
   rowsCount = 5,
@@ -53,7 +49,7 @@ const SkeletonTable: React.FunctionComponent<SkeletonTableProps> = ({
   return (
     <Table aria-label="Loading" variant={variant} borders={borders} ouiaId={ouiaId} {...rest}>
       {caption && <Caption>{caption}</Caption>}
-      <SkeletonTableHead 
+      <SkeletonTableHead
         ouiaId={ouiaId}
         isSelectable={isSelectable}
         isExpandable={isExpandable}
@@ -61,7 +57,7 @@ const SkeletonTable: React.FunctionComponent<SkeletonTableProps> = ({
         columns={columns}
         isTreeTable={isTreeTable}
       />
-      <SkeletonTableBody 
+      <SkeletonTableBody
         columnsCount={rowCellsCount ?? 0}
         rowsCount={rowsCount}
         isSelectable={isSelectable}

--- a/packages/module/src/SkeletonTableBody/SkeletonTableBody.test.tsx
+++ b/packages/module/src/SkeletonTableBody/SkeletonTableBody.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import SkeletonTableBody from './SkeletonTableBody';
 import { Table } from '@patternfly/react-table';

--- a/packages/module/src/SkeletonTableBody/SkeletonTableBody.tsx
+++ b/packages/module/src/SkeletonTableBody/SkeletonTableBody.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import {
   Tbody,
   Td,
@@ -22,7 +22,7 @@ export interface SkeletonTableBodyProps {
   selectVariant?: RowSelectVariant;
 }
 
-const SkeletonTableBody: React.FunctionComponent<SkeletonTableBodyProps> = ({
+const SkeletonTableBody: FunctionComponent<SkeletonTableBodyProps> = ({
   rowsCount = 5,
   ouiaId = 'SkeletonTableBody',
   isSelectable,

--- a/packages/module/src/SkeletonTableHead/SkeletonTableHead.test.tsx
+++ b/packages/module/src/SkeletonTableHead/SkeletonTableHead.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import SkeletonTableHead from './SkeletonTableHead';
 import { Table } from '@patternfly/react-table';

--- a/packages/module/src/SkeletonTableHead/SkeletonTableHead.tsx
+++ b/packages/module/src/SkeletonTableHead/SkeletonTableHead.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, useMemo } from 'react';
+import type { FunctionComponent } from 'react';
+import { ReactNode, useMemo } from 'react';
 import {
   Th,
   ThProps,
@@ -24,7 +25,7 @@ export interface SkeletonTableHeadProps {
   isTreeTable?: boolean;
 }
 
-export const SkeletonTableHead: React.FunctionComponent<SkeletonTableHeadProps> = ({
+export const SkeletonTableHead: FunctionComponent<SkeletonTableHeadProps> = ({
   ouiaId = 'SkeletonTableHeader',
   isSelectable,
   isExpandable,

--- a/packages/module/src/StaleDataWarning/StaleDataWarning.tsx
+++ b/packages/module/src/StaleDataWarning/StaleDataWarning.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import type { ReactElement, FunctionComponent } from 'react';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Button, Icon, Tooltip, TooltipProps } from '@patternfly/react-core';
 import clsx from 'clsx';
 import { createUseStyles } from 'react-jss';
 
-type Render = (config: { msg: string }) => React.ReactElement<any, any> | null;
+type Render = (config: { msg: string }) => ReactElement<any, any> | null;
 type CullingDate = string | number | Date;
 
 interface StaleDataInfo {
@@ -54,10 +54,10 @@ export interface StaleDataWarningProps extends Omit<TooltipProps, 'content'> {
   /** Optional custom warning message */
   message?: string;
   /** Accessible label for the icon */
-  "aria-label"?: string;
+  'aria-label'?: string;
 }
 
-const StaleDataWarning: React.FunctionComponent<StaleDataWarningProps> = ({
+const StaleDataWarning: FunctionComponent<StaleDataWarningProps> = ({
   culled = new Date(0),
   className,
   staleWarning = new Date(0),

--- a/packages/module/src/Status/Status.test.tsx
+++ b/packages/module/src/Status/Status.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import Status, { IconStatus, StatusVariant } from './Status';
 import { BanIcon, CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';

--- a/packages/module/src/Status/Status.tsx
+++ b/packages/module/src/Status/Status.tsx
@@ -1,5 +1,16 @@
-import * as React from 'react';
-import { Button, ButtonVariant, Flex, FlexItem, Icon, Popover, PopoverPosition, PopoverProps, Content, ContentVariants, } from '@patternfly/react-core';
+import { FC } from 'react';
+import {
+  Button,
+  ButtonVariant,
+  Flex,
+  FlexItem,
+  Icon,
+  Popover,
+  PopoverPosition,
+  PopoverProps,
+  Content,
+  ContentVariants
+} from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
 
 export const StatusVariant = {
@@ -8,7 +19,7 @@ export const StatusVariant = {
   plain: 'plain'
 } as const;
 
-export type StatusVariant = typeof StatusVariant[keyof typeof StatusVariant];
+export type StatusVariant = (typeof StatusVariant)[keyof typeof StatusVariant];
 
 export const IconStatus = {
   custom: 'custom',
@@ -18,7 +29,7 @@ export const IconStatus = {
   danger: 'danger'
 } as const;
 
-export type IconStatus = typeof IconStatus[keyof typeof IconStatus];
+export type IconStatus = (typeof IconStatus)[keyof typeof IconStatus];
 
 export interface StatusProps extends React.PropsWithChildren {
   /** Status label text */
@@ -45,38 +56,68 @@ export interface StatusProps extends React.PropsWithChildren {
 
 const useStyles = createUseStyles({
   icon: {
-    margin: "0",
-    alignSelf: "flex-start",
+    margin: '0',
+    alignSelf: 'flex-start'
   },
   statusLabel: {
-    lineHeight: 'var(--pf-t--global--font--line-height--body)',
+    lineHeight: 'var(--pf-t--global--font--line-height--body)'
   },
   statusDescription: {
-    color: 'var(--pf-t--color--gray--50)',
+    color: 'var(--pf-t--color--gray--50)'
   }
-})
+});
 
-export const Status: React.FC<StatusProps> = ({ variant = StatusVariant.plain, label, children, iconOnly, icon, status, iconTitle, ouiaId = 'Status', popoverProps, onClick, description, ...props }: StatusProps) => {
+export const Status: FC<StatusProps> = ({
+  variant = StatusVariant.plain,
+  label,
+  children,
+  iconOnly,
+  icon,
+  status,
+  iconTitle,
+  ouiaId = 'Status',
+  popoverProps,
+  onClick,
+  description,
+  ...props
+}: StatusProps) => {
   const classes = useStyles();
 
   if (iconOnly && !iconTitle) {
     // eslint-disable-next-line no-console
-    console.warn('iconOnly is true but no iconTitle is provided. Please provide a descriptive iconTitle for accessibility.');
+    console.warn(
+      'iconOnly is true but no iconTitle is provided. Please provide a descriptive iconTitle for accessibility.'
+    );
   }
 
   const statusBody = (
     <Flex title={label} alignItems={{ default: 'alignItemsCenter' }} {...props}>
       {icon && (
         <FlexItem className={classes.icon}>
-          <Icon className='pf-v6-u-mr-sm' status={status} title={iconTitle ?? status} data-ouia-component-id={`${ouiaId}-icon`}>
+          <Icon
+            className="pf-v6-u-mr-sm"
+            status={status}
+            title={iconTitle ?? status}
+            data-ouia-component-id={`${ouiaId}-icon`}
+          >
             {icon}
           </Icon>
         </FlexItem>
       )}
       {!iconOnly && (
         <FlexItem>
-          <Content ouiaId={`${ouiaId}-label`} className={classes.statusLabel} style={{ marginBlockEnd: 0 }}>{label}</Content>
-          {description && <Content component={ContentVariants.small} ouiaId={`${ouiaId}-description`} className={classes.statusDescription}>{description}</Content>}
+          <Content ouiaId={`${ouiaId}-label`} className={classes.statusLabel} style={{ marginBlockEnd: 0 }}>
+            {label}
+          </Content>
+          {description && (
+            <Content
+              component={ContentVariants.small}
+              ouiaId={`${ouiaId}-description`}
+              className={classes.statusDescription}
+            >
+              {description}
+            </Content>
+          )}
         </FlexItem>
       )}
     </Flex>
@@ -100,7 +141,12 @@ export const Status: React.FC<StatusProps> = ({ variant = StatusVariant.plain, l
         data-ouia-component-id={`${ouiaId}-popover`}
         {...popoverProps}
       >
-        <Button variant={ButtonVariant.link} isInline style={{ textDecoration: 'none' }} ouiaId={`${ouiaId}-popover-icon`}>
+        <Button
+          variant={ButtonVariant.link}
+          isInline
+          style={{ textDecoration: 'none' }}
+          ouiaId={`${ouiaId}-popover-icon`}
+        >
           {statusBody}
         </Button>
       </Popover>

--- a/packages/module/src/TagCount/TagCount.test.tsx
+++ b/packages/module/src/TagCount/TagCount.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import TagCount from './TagCount';
 

--- a/packages/module/src/TagCount/TagCount.tsx
+++ b/packages/module/src/TagCount/TagCount.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import clsx from 'clsx';
 import { Button, ButtonProps, Icon } from '@patternfly/react-core';
 import { TagIcon } from '@patternfly/react-icons';
@@ -33,7 +33,7 @@ export interface TagCountProps extends ButtonProps {
   ouiaId?: string | number;
 }
 
-const TagCount: React.FunctionComponent<TagCountProps> = ({
+const TagCount: FunctionComponent<TagCountProps> = ({
   count, 
   className,
   iconSize= 'md',

--- a/packages/module/src/UnauthorizedAccess/UnauthorizedAccess.test.tsx
+++ b/packages/module/src/UnauthorizedAccess/UnauthorizedAccess.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import UnauthorizedAccess from './UnauthorizedAccess';

--- a/packages/module/src/UnauthorizedAccess/UnauthorizedAccess.tsx
+++ b/packages/module/src/UnauthorizedAccess/UnauthorizedAccess.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import { Button, EmptyState, EmptyStateBody, EmptyStateProps, EmptyStateVariant, EmptyStateFooter, EmptyStateActions, ButtonVariant, } from '@patternfly/react-core';
 import { LockIcon } from '@patternfly/react-icons';
 
@@ -30,7 +30,7 @@ export interface UnauthorizedAccessProps extends Omit<EmptyStateProps, 'children
   ouiaId?: string | number;
 }
 
-const UnauthorizedAccess: React.FunctionComponent<UnauthorizedAccessProps> = ({
+const UnauthorizedAccess: FunctionComponent<UnauthorizedAccessProps> = ({
   prevPageButtonText = 'Return to previous page',
   toLandingPageText = 'Go to landing page',
   toLandingPageUrl = ".",

--- a/packages/module/src/UnavailableContent/UnavailableContent.test.tsx
+++ b/packages/module/src/UnavailableContent/UnavailableContent.test.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { render } from '@testing-library/react';  
+import { render } from '@testing-library/react';
 import UnavailableContent from './UnavailableContent';
 
 describe('Unavailable component', () => {

--- a/packages/module/src/UnavailableContent/UnavailableContent.tsx
+++ b/packages/module/src/UnavailableContent/UnavailableContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 import { Button, EmptyState, EmptyStateBody, EmptyStateFooter, EmptyStateProps, EmptyStateStatus, EmptyStateVariant } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -16,7 +16,7 @@ export interface UnavailableContentProps extends Omit<EmptyStateProps, 'children
   ouiaId?: string | number;
 }
 
-const UnavailableContent: React.FunctionComponent<UnavailableContentProps> = ({ 
+const UnavailableContent: FunctionComponent<UnavailableContentProps> = ({ 
   statusPageUrl = '',
   statusPageLinkText = 'Status Page',
   titleText = 'This page is temporarily unavailable',

--- a/packages/module/src/WarningModal/WarningModal.test.tsx
+++ b/packages/module/src/WarningModal/WarningModal.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import WarningModal from './WarningModal';
 

--- a/packages/module/src/WarningModal/WarningModal.tsx
+++ b/packages/module/src/WarningModal/WarningModal.tsx
@@ -1,5 +1,15 @@
-import React, { ReactNode, useState } from 'react';
-import { Button, ButtonVariant, Checkbox, Flex, FlexItem, Stack, StackItem, TextInput, TextInputProps } from '@patternfly/react-core';
+import { FunctionComponent, useMemo, useState } from 'react';
+import {
+  Button,
+  ButtonVariant,
+  Checkbox,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  TextInput,
+  TextInputProps
+} from '@patternfly/react-core';
 import { ModalProps, Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 
 /** extends ModalProps */
@@ -13,7 +23,7 @@ export interface WarningModalProps extends Omit<ModalProps, 'ref'> {
   /** Whether modal requires a checkbox before confirming */
   withCheckbox?: boolean;
   /** Custom checkbox label */
-  checkboxLabel?: ReactNode;
+  checkboxLabel?: React.ReactNode;
   /** Visual variant of the confirm button */
   confirmButtonVariant?: ButtonVariant;
   /** Custom OUIA ID */
@@ -23,10 +33,10 @@ export interface WarningModalProps extends Omit<ModalProps, 'ref'> {
   /** Text the user should type to confirm selection when using confirmation input */
   confirmationText?: string;
   /** Label for the text confirmation input */
-  confirmationInputLabel?: ReactNode;
+  confirmationInputLabel?: React.ReactNode;
 }
 
-const WarningModal: React.FunctionComponent<WarningModalProps> = ({
+const WarningModal: FunctionComponent<WarningModalProps> = ({
   isOpen,
   onConfirm,
   onClose,
@@ -36,22 +46,26 @@ const WarningModal: React.FunctionComponent<WarningModalProps> = ({
   variant = ModalVariant.small,
   titleIconVariant = 'warning',
   withCheckbox = false,
-  checkboxLabel='I understand that this action cannot be undone',
+  checkboxLabel = 'I understand that this action cannot be undone',
   confirmButtonVariant = ButtonVariant.primary,
   ouiaId = 'WarningModal',
   confirmationInputProps,
   confirmationText,
-  confirmationInputLabel = <>Type <strong>{confirmationText} </strong> to confirm the action:</>,
+  confirmationInputLabel = (
+    <>
+      Type <strong>{confirmationText} </strong> to confirm the action:
+    </>
+  ),
   ...props
 }: WarningModalProps) => {
   const [ checked, setChecked ] = useState(false);
-  const [ inputValue, setInputValue ] = React.useState('');
+  const [ inputValue, setInputValue ] = useState('');
 
-  const deleteNameSanitized = React.useMemo(() => confirmationText?.trim().replace(/\s+/g, ' '), [ confirmationText ]);
+  const deleteNameSanitized = useMemo(() => confirmationText?.trim().replace(/\s+/g, ' '), [ confirmationText ]);
 
   const textConfirmed = confirmationInputProps ? inputValue.trim() === deleteNameSanitized : true;
 
-  const isConfirmButtonDisabled = React.useMemo(() => {
+  const isConfirmButtonDisabled = useMemo(() => {
     if (withCheckbox) {
       return !checked || (confirmationInputProps && !textConfirmed);
     }
@@ -78,14 +92,9 @@ const WarningModal: React.FunctionComponent<WarningModalProps> = ({
         >
           {confirmButtonLabel}
         </Button>,
-        <Button
-          ouiaId={`${ouiaId}-cancel-button`}
-          key="cancel"
-          variant={ButtonVariant.link}
-          onClick={onClose}
-        >
+        <Button ouiaId={`${ouiaId}-cancel-button`} key="cancel" variant={ButtonVariant.link} onClick={onClose}>
           {cancelButtonLabel}
-        </Button>,
+        </Button>
       ]}
       ouiaId={ouiaId}
       {...props}
@@ -95,9 +104,7 @@ const WarningModal: React.FunctionComponent<WarningModalProps> = ({
         <StackItem>
           {confirmationText ? (
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-              <FlexItem>
-                {confirmationInputLabel}
-              </FlexItem>
+              <FlexItem>{confirmationInputLabel}</FlexItem>
               <TextInput
                 ouiaId={`${ouiaId}-confirmation-text-input`}
                 value={inputValue}
@@ -105,7 +112,7 @@ const WarningModal: React.FunctionComponent<WarningModalProps> = ({
                 {...{ type: 'text', isRequired: true, ...confirmationInputProps }}
               />
             </Flex>
-          ) : null}          
+          ) : null}
         </StackItem>
         <StackItem>
           {withCheckbox ? (
@@ -121,9 +128,7 @@ const WarningModal: React.FunctionComponent<WarningModalProps> = ({
         </StackItem>
       </Stack>
     </Modal>
-  )
-
+  );
 };
-
 
 export default WarningModal;

--- a/packages/module/tsconfig.json
+++ b/packages/module/tsconfig.json
@@ -9,7 +9,7 @@
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
-    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
+    "jsx": "react-jsx" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
@@ -26,7 +26,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitAny": false,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,                    /* Enable strict null checks. */
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
     // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -49,7 +49,7 @@
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    "types": ["@testing-library/jest-dom"],         /* Type declaration files to be included in compilation. */
+    "types": ["@testing-library/jest-dom", "react"] /* Type declaration files to be included in compilation. */,
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
@@ -69,5 +69,5 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["./src/*", "./src/**/*", "./cypress/**/*"],
+  "include": ["./src/*", "./src/**/*", "./cypress/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
-    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
+    "jsx": "react-jsx" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
@@ -26,7 +26,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitAny": false,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,                    /* Enable strict null checks. */
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
     // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -69,5 +69,5 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["./cypress/**/*"],
+  "include": ["./cypress/**/*"]
 }


### PR DESCRIPTION
Did not run into the same circular dependency issues as I did in ChatBot, but changing the React dev dependency breaks the docs framework. It does build with every React version, but the docs framework stops working with 19. Leaving the dev dependency at 18 for now until we can drop the docs framework.