### PR TITLE
feat(BulkSelect): expose menuToggle props

### DIFF
--- a/packages/module/src/BulkSelect/BulkSelect.test.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.test.tsx
@@ -40,4 +40,33 @@ describe('BulkSelect component', () => {
     expect(dropdownList).toBeInTheDocument();
     expect(dropdownList).toHaveClass('pf-v6-c-menu__list');
   });
+
+  test('should render with menuToggleProps', () => {
+    render(
+      <BulkSelect
+        canSelectAll
+        pageCount={5}
+        totalCount={10}
+        selectedCount={2}
+        pageSelected={false}
+        pagePartiallySelected={true}
+        onSelect={() => null}
+        menuToggleProps={{ isDisabled: true, className: 'custom-menu-toggle' }}
+      />
+    );
+
+    const toggleButton = screen.getByLabelText('Bulk select toggle');
+    expect(toggleButton).toBeInTheDocument();
+
+    // Confirm the split button toggle is disabled
+    expect(toggleButton).toBeDisabled();
+
+    // Confirm the split button toggle receives the correct PatternFly class
+    expect(toggleButton).toHaveClass('pf-v6-c-menu-toggle__button');
+
+    // Confirm the split button toggle wrapper receives the custom class
+    const toggleWrapper = toggleButton.parentElement;
+    expect(toggleWrapper).toBeInTheDocument();
+    expect(toggleWrapper).toHaveClass('custom-menu-toggle');
+  });
 });

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -9,7 +9,8 @@ import {
   MenuToggle,
   MenuToggleCheckbox,
   MenuToggleCheckboxProps,
-  MenuToggleElement
+  MenuToggleElement,
+  MenuToggleProps
 } from '@patternfly/react-core';
 
 export const BulkSelectValue = {
@@ -47,6 +48,8 @@ export interface BulkSelectProps extends Omit<DropdownProps, 'toggle' | 'onSelec
   menuToggleCheckboxProps?: Omit<MenuToggleCheckboxProps, 'onChange' | 'isChecked' | 'instance' | 'ref'>;
   /** Additional props for DropdownList */
   dropdownListProps?: Omit<DropdownListProps, 'children'>;
+  /** Additional props for MenuToggleProps */
+  menuToggleProps?: Omit<MenuToggleProps, 'children' | 'splitButtonItems' | 'ref' | 'isExpanded' | 'onClick'>;
 }
 
 export const BulkSelect: FC<BulkSelectProps> = ({
@@ -61,6 +64,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
   onSelect,
   menuToggleCheckboxProps,
   dropdownListProps,
+  menuToggleProps,
   ...props
 }: BulkSelectProps) => {
   const [ isOpen, setOpen ] = useState(false);
@@ -116,7 +120,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
               aria-label={`Select ${allOption}`}
               isChecked={
                 (isDataPaginated && pagePartiallySelected) ||
-                  (!isDataPaginated && selectedCount > 0 && selectedCount < totalCount)
+                (!isDataPaginated && selectedCount > 0 && selectedCount < totalCount)
                   ? null
                   : pageSelected || (selectedCount === totalCount && totalCount > 0)
               }
@@ -129,6 +133,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
               </span>
             ) : null
           ]}
+          {...menuToggleProps}
         />
       )}
       {...props}


### PR DESCRIPTION
Expose additional `menuToggleProps` in the component's API. This is necessary for the Content Services use case, as we need to programmatically disable the split button toggle.