### PR TITLE
feat(BulkSelect): add internationalization (i18n) support

### DIFF
--- a/packages/module/src/BulkSelect/BulkSelect.test.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.test.tsx
@@ -69,4 +69,35 @@ describe('BulkSelect component', () => {
     expect(toggleWrapper).toBeInTheDocument();
     expect(toggleWrapper).toHaveClass('custom-menu-toggle');
   });
+
+  test('should render with custom i18n labels', async () => {
+    const user = userEvent.setup();
+    render(
+      <BulkSelect
+        canSelectAll
+        pageCount={5}
+        totalCount={10}
+        selectedCount={2}
+        pageSelected={false}
+        pagePartiallySelected={true}
+        onSelect={() => null}
+        selectNoneLabel="Aucune sélection (0)"
+        selectPageLabel={(pageCount) => `Sélectionner la page${pageCount ? ` (${pageCount})` : ''}`}
+        selectAllLabel={(totalCount) => `Tout sélectionner${totalCount ? ` (${totalCount})` : ''}`}
+        selectedLabel={(selectedCount) => `${selectedCount} sélectionné${selectedCount > 1 ? 's' : ''}`}
+      />
+    );
+
+    // Check custom selected label
+    expect(screen.getByText('2 sélectionnés')).toBeInTheDocument();
+
+    // Open the dropdown to check option labels
+    const toggleButton = screen.getByLabelText('Bulk select toggle');
+    await user.click(toggleButton);
+
+    // Check custom dropdown labels
+    expect(screen.getByText('Aucune sélection (0)')).toBeInTheDocument();
+    expect(screen.getByText('Sélectionner la page (5)')).toBeInTheDocument();
+    expect(screen.getByText('Tout sélectionner (10)')).toBeInTheDocument();
+  });
 });

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -22,6 +22,10 @@ export const BulkSelectValue = {
 
 export type BulkSelectValue = (typeof BulkSelectValue)[keyof typeof BulkSelectValue];
 
+const defaultSelectPageLabel = (pageCount?: number) => `Select page${pageCount ? ` (${pageCount})` : ''}`;
+const defaultSelectAllLabel = (totalCount?: number) => `Select all${totalCount ? ` (${totalCount})` : ''}`;
+const defaultSelectedLabel = (selectedCount: number) => `${selectedCount} selected`;
+
 /** extends DropdownProps */
 export interface BulkSelectProps extends Omit<DropdownProps, 'toggle' | 'onSelect'> {
   /** BulkSelect className */
@@ -50,6 +54,14 @@ export interface BulkSelectProps extends Omit<DropdownProps, 'toggle' | 'onSelec
   dropdownListProps?: Omit<DropdownListProps, 'children'>;
   /** Additional props for MenuToggleProps */
   menuToggleProps?: Omit<MenuToggleProps, 'children' | 'splitButtonItems' | 'ref' | 'isExpanded' | 'onClick'>;
+  /** Custom label for "Select none" option. Defaults to "Select none (0)" */
+  selectNoneLabel?: string;
+  /** Custom label for "Select page" option. Receives pageCount as parameter. Defaults to "Select page (N)" */
+  selectPageLabel?: (pageCount?: number) => string;
+  /** Custom label for "Select all" option. Receives totalCount as parameter. Defaults to "Select all (N)" */
+  selectAllLabel?: (totalCount?: number) => string;
+  /** Custom label formatter for selected count. Receives selectedCount as parameter. Defaults to "N selected" */
+  selectedLabel?: (selectedCount: number) => string;
 }
 
 export const BulkSelect: FC<BulkSelectProps> = ({
@@ -65,6 +77,10 @@ export const BulkSelect: FC<BulkSelectProps> = ({
   menuToggleCheckboxProps,
   dropdownListProps,
   menuToggleProps,
+  selectNoneLabel = 'Select none (0)',
+  selectPageLabel = defaultSelectPageLabel,
+  selectAllLabel = defaultSelectAllLabel,
+  selectedLabel = defaultSelectedLabel,
   ...props
 }: BulkSelectProps) => {
   const [ isOpen, setOpen ] = useState(false);
@@ -73,22 +89,24 @@ export const BulkSelect: FC<BulkSelectProps> = ({
     () => (
       <>
         <DropdownItem ouiaId={`${ouiaId}-select-none`} value={BulkSelectValue.none} key={BulkSelectValue.none}>
-          Select none (0)
+          {selectNoneLabel}
         </DropdownItem>
         {isDataPaginated && (
           <DropdownItem ouiaId={`${ouiaId}-select-page`} value={BulkSelectValue.page} key={BulkSelectValue.page}>
-            {`Select page${pageCount ? ` (${pageCount})` : ''}`}
+            {selectPageLabel(pageCount)}
           </DropdownItem>
         )}
         {canSelectAll && (
           <DropdownItem ouiaId={`${ouiaId}-select-all`} value={BulkSelectValue.all} key={BulkSelectValue.all}>
-            {`Select all${totalCount ? ` (${totalCount})` : ''}`}
+            {selectAllLabel(totalCount)}
           </DropdownItem>
         )}
       </>
     ),
-    [ isDataPaginated, canSelectAll, ouiaId, pageCount, totalCount ]
+    [ isDataPaginated, canSelectAll, ouiaId, selectNoneLabel, selectPageLabel, selectAllLabel, pageCount, totalCount ]
   );
+
+  const selectedLabelText = selectedLabel(selectedCount);
 
   const allOption = isDataPaginated ? BulkSelectValue.page : BulkSelectValue.all;
   const noneOption = isDataPaginated ? BulkSelectValue.nonePage : BulkSelectValue.none;
@@ -129,7 +147,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
             >
               {selectedCount > 0 ? (
                 <span data-ouia-component-id={`${ouiaId}-text`}>
-                  {`${selectedCount} selected`}
+                  {selectedLabelText}
                 </span>
               ) : null}
             </MenuToggleCheckbox>


### PR DESCRIPTION
## Summary
- Fixes #895
- Adds optional props for customizing all user-facing strings in BulkSelect
- Maintains full backward compatibility with sensible English defaults

## Details
Applications using BulkSelect that need to support non-English languages or custom terminology can now provide custom labels for all user-facing strings.

### New Props
All props are optional with English defaults:

- **`selectNoneLabel`**: Custom label for "Select none" option (default: `"Select none (0)"`)
- **`selectPageLabel`**: Function receiving `pageCount` to format "Select page" label (default: `` `Select page${pageCount ? ` (${pageCount})` : ''}` ``)
- **`selectAllLabel`**: Function receiving `totalCount` to format "Select all" label (default: `` `Select all${totalCount ? ` (${totalCount})` : ''}` ``)
- **`selectedLabel`**: Function receiving `selectedCount` to format the displayed count (default: `` `${selectedCount} selected` ``)

### Example Usage
```tsx
import { useTranslation } from 'react-i18next';

const MyComponent = () => {
  const { t } = useTranslation();
  
  return (
    <BulkSelect
      selectedCount={5}
      totalCount={100}
      pageCount={20}
      onSelect={handleSelect}
      selectNoneLabel={t('bulkSelect.selectNone')}
      selectPageLabel={(pageCount) => t('bulkSelect.selectPage', { pageCount })}
      selectAllLabel={(totalCount) => t('bulkSelect.selectAll', { totalCount })}
      selectedLabel={(selectedCount) => t('bulkSelect.selected', { selectedCount })}
    />
  );
};
```

**Note:** Parameter names (`pageCount`, `totalCount`, `selectedCount`) are deliberately chosen to avoid conflicts with i18n reserved keywords like `count` used for pluralization.

## Test plan
- [x] All existing tests pass (backward compatibility maintained)
- [x] Added new test with French labels to verify i18n functionality
- [x] Build completes successfully
- [x] No breaking changes - existing usage works exactly as before
- [x] Parameter names avoid i18n reserved keyword conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)