### PR TITLE
feat(BulkSelect): extend onSelect with second parameter source

### DIFF
--- a/packages/module/src/BulkSelect/BulkSelect.test.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.test.tsx
@@ -1,19 +1,22 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import BulkSelect from './BulkSelect';
+import BulkSelect, { BulkSelectValue } from './BulkSelect';
 
 describe('BulkSelect component', () => {
   test('should render', () => {
-    expect(render(
-      <BulkSelect
-        canSelectAll
-        pageCount={5}
-        totalCount={10}
-        selectedCount={2}
-        pageSelected={false}
-        pagePartiallySelected={true}
-        onSelect={() => null}
-      />)).toMatchSnapshot();
+    expect(
+      render(
+        <BulkSelect
+          canSelectAll
+          pageCount={5}
+          totalCount={10}
+          selectedCount={2}
+          pageSelected={false}
+          pagePartiallySelected={true}
+          onSelect={() => null}
+        />
+      )
+    ).toMatchSnapshot();
   });
 
   test('should render with dropdownListProps', async () => {
@@ -121,6 +124,7 @@ describe('BulkSelect component', () => {
 
   test('should enable Select none when at least one row is selected', async () => {
     const user = userEvent.setup();
+
     render(
       <BulkSelect
         canSelectAll
@@ -135,5 +139,59 @@ describe('BulkSelect component', () => {
 
     await user.click(screen.getByLabelText('Bulk select toggle'));
     expect(screen.getByRole('menuitem', { name: 'Select none (0)' })).not.toBeDisabled();
+  });
+
+  test('should call onSelect with source "dropdown" when choosing menu items', async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+
+    render(
+      <BulkSelect
+        canSelectAll
+        pageCount={5}
+        totalCount={10}
+        selectedCount={1}
+        pageSelected={false}
+        pagePartiallySelected={true}
+        onSelect={onSelect}
+      />
+    );
+
+    const openMenu = async () => {
+      await user.click(screen.getByLabelText('Bulk select toggle'));
+    };
+
+    await openMenu();
+    await user.click(screen.getByRole('menuitem', { name: 'Select none (0)' }));
+    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.none, 'dropdown');
+
+    onSelect.mockClear();
+    await openMenu();
+    await user.click(screen.getByRole('menuitem', { name: 'Select page (5)' }));
+    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.page, 'dropdown');
+
+    onSelect.mockClear();
+    await openMenu();
+    await user.click(screen.getByRole('menuitem', { name: 'Select all (10)' }));
+    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.all, 'dropdown');
+  });
+
+  test('should call onSelect with source "checkbox" when using split checkbox', async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    render(
+      <BulkSelect
+        canSelectAll
+        pageCount={5}
+        totalCount={10}
+        selectedCount={0}
+        pageSelected={false}
+        pagePartiallySelected={false}
+        onSelect={onSelect}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select page' }));
+    expect(onSelect).toHaveBeenCalledWith(BulkSelectValue.page, 'checkbox');
   });
 });

--- a/packages/module/src/BulkSelect/BulkSelect.test.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import BulkSelect, { BulkSelectValue } from './BulkSelect';
+import BulkSelect, { BulkSelectSource, BulkSelectValue } from './BulkSelect';
 
 describe('BulkSelect component', () => {
   test('should render', () => {
@@ -141,7 +141,7 @@ describe('BulkSelect component', () => {
     expect(screen.getByRole('menuitem', { name: 'Select none (0)' })).not.toBeDisabled();
   });
 
-  test('should call onSelect with source "dropdown" when choosing menu items', async () => {
+  test(`should call onSelect with source ${BulkSelectSource.dropdown} when choosing menu items`, async () => {
     const user = userEvent.setup();
     const onSelect = jest.fn();
 
@@ -163,20 +163,20 @@ describe('BulkSelect component', () => {
 
     await openMenu();
     await user.click(screen.getByRole('menuitem', { name: 'Select none (0)' }));
-    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.none, 'dropdown');
+    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.none, BulkSelectSource.dropdown);
 
     onSelect.mockClear();
     await openMenu();
     await user.click(screen.getByRole('menuitem', { name: 'Select page (5)' }));
-    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.page, 'dropdown');
+    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.page, BulkSelectSource.dropdown);
 
     onSelect.mockClear();
     await openMenu();
     await user.click(screen.getByRole('menuitem', { name: 'Select all (10)' }));
-    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.all, 'dropdown');
+    expect(onSelect).toHaveBeenLastCalledWith(BulkSelectValue.all, BulkSelectSource.dropdown);
   });
 
-  test('should call onSelect with source "checkbox" when using split checkbox', async () => {
+  test(`should call onSelect with source ${BulkSelectSource.checkbox} when using split checkbox`, async () => {
     const user = userEvent.setup();
     const onSelect = jest.fn();
     render(
@@ -192,6 +192,6 @@ describe('BulkSelect component', () => {
     );
 
     await user.click(screen.getByRole('checkbox', { name: 'Select page' }));
-    expect(onSelect).toHaveBeenCalledWith(BulkSelectValue.page, 'checkbox');
+    expect(onSelect).toHaveBeenCalledWith(BulkSelectValue.page, BulkSelectSource.checkbox);
   });
 });

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -22,6 +22,8 @@ export const BulkSelectValue = {
 
 export type BulkSelectValue = (typeof BulkSelectValue)[keyof typeof BulkSelectValue];
 
+export type BulkSelectSource = 'dropdown' | 'checkbox';
+
 const defaultSelectPageLabel = (pageCount?: number) => `Select page${pageCount ? ` (${pageCount})` : ''}`;
 const defaultSelectAllLabel = (totalCount?: number) => `Select all${totalCount ? ` (${totalCount})` : ''}`;
 const defaultSelectedLabel = (selectedCount: number) => `${selectedCount} selected`;
@@ -45,7 +47,7 @@ export interface BulkSelectProps extends Omit<DropdownProps, 'toggle' | 'onSelec
   /** Indicates if ONLY some current page items are selected */
   pagePartiallySelected?: boolean;
   /** Callback called on item select */
-  onSelect: (value: BulkSelectValue) => void;
+  onSelect: (value: BulkSelectValue, source?: BulkSelectSource) => void;
   /** Custom OUIA ID */
   ouiaId?: string;
   /** Additional props for MenuToggleCheckbox */
@@ -124,7 +126,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
       ouiaId={`${ouiaId}-dropdown`}
       onSelect={(_e, value) => {
         setOpen(!isOpen);
-        onSelect?.(value as BulkSelectValue);
+        onSelect?.(value as BulkSelectValue, 'dropdown');
       }}
       isOpen={isOpen}
       onOpenChange={(isOpen: boolean) => setOpen(isOpen)}
@@ -147,7 +149,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
                   ? null
                   : pageSelected || (selectedCount === totalCount && totalCount > 0)
               }
-              onChange={(checked) => onSelect?.(!checked || checked === null ? noneOption : allOption)}
+              onChange={(checked) => onSelect?.(!checked || checked === null ? noneOption : allOption, 'checkbox')}
               {...menuToggleCheckboxProps}
             >
               {selectedCount > 0 ? (

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -128,7 +128,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
       ouiaId={`${ouiaId}-dropdown`}
       onSelect={(_e, value) => {
         setOpen(!isOpen);
-        onSelect?.(value as BulkSelectValue, 'dropdown');
+        onSelect?.(value as BulkSelectValue, BulkSelectSource.dropdown);
       }}
       isOpen={isOpen}
       onOpenChange={(isOpen: boolean) => setOpen(isOpen)}

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -22,8 +22,10 @@ export const BulkSelectValue = {
 
 export type BulkSelectValue = (typeof BulkSelectValue)[keyof typeof BulkSelectValue];
 
-export type BulkSelectSource = 'dropdown' | 'checkbox';
-
+export const BulkSelectSource = {
+    dropdown: 'dropdown',
+    checkbox: 'checkbox'
+  } as const;
 const defaultSelectPageLabel = (pageCount?: number) => `Select page${pageCount ? ` (${pageCount})` : ''}`;
 const defaultSelectAllLabel = (totalCount?: number) => `Select all${totalCount ? ` (${totalCount})` : ''}`;
 const defaultSelectedLabel = (selectedCount: number) => `${selectedCount} selected`;

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -151,7 +151,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
                   ? null
                   : pageSelected || (selectedCount === totalCount && totalCount > 0)
               }
-              onChange={(checked) => onSelect?.(!checked || checked === null ? noneOption : allOption, 'checkbox')}
+              onChange={(checked) => onSelect?.(!checked || checked === null ? noneOption : allOption, BulkSelectSource.checkbox)}
               {...menuToggleCheckboxProps}
             >
               {selectedCount > 0 ? (

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -23,9 +23,12 @@ export const BulkSelectValue = {
 export type BulkSelectValue = (typeof BulkSelectValue)[keyof typeof BulkSelectValue];
 
 export const BulkSelectSource = {
-    dropdown: 'dropdown',
-    checkbox: 'checkbox'
-  } as const;
+  dropdown: 'dropdown',
+  checkbox: 'checkbox'
+} as const;
+
+export type BulkSelectSource = (typeof BulkSelectSource)[keyof typeof BulkSelectSource];
+
 const defaultSelectPageLabel = (pageCount?: number) => `Select page${pageCount ? ` (${pageCount})` : ''}`;
 const defaultSelectAllLabel = (totalCount?: number) => `Select all${totalCount ? ` (${totalCount})` : ''}`;
 const defaultSelectedLabel = (selectedCount: number) => `${selectedCount} selected`;
@@ -123,7 +126,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
   const onToggleClick = () => setOpen(!isOpen);
 
   return (
-    (<Dropdown
+    <Dropdown
       shouldFocusToggleOnSelect
       ouiaId={`${ouiaId}-dropdown`}
       onSelect={(_e, value) => {
@@ -167,7 +170,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
       {...props}
     >
       <DropdownList {...dropdownListProps}>{splitButtonDropdownItems}</DropdownList>
-    </Dropdown>)
+    </Dropdown>
   );
 };
 


### PR DESCRIPTION
## What this does

onSelect now receives an optional second argument: source

onSelect is still (value: BulkSelectValue, source?: BulkSelectSource) => void. The first argument is unchanged: the same BulkSelectValue as today (none, page, all, nonePage, depending on pagination and which action the user chose).

The optional second argument tells which control triggered the callback:

'dropdown' — the user picked an option fron the bulk-select menu (e.g. “Select none”, “Select page”, “Select all”).
'checkbox' — the user toggled the split menu toggle checkbox (the quick select/deselect for the current page vs not paginated “all” behavior, as before).

## Why we need this

We're trying to implement slightly different handling when the action comes from the dropdown menu vs the checkbox. The original API doesn't allow this.

## Backward compatibility

Existing onSelect handlers that only take value keep working; the extra argument is optional at the type level and is ignored at runtime if not used.
