### PR TITLE
feat(BulkSelect): disable Select none option when no rows are selected

### DIFF
--- a/packages/module/src/BulkSelect/BulkSelect.test.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.test.tsx
@@ -100,4 +100,40 @@ describe('BulkSelect component', () => {
     expect(screen.getByText('Sélectionner la page (5)')).toBeInTheDocument();
     expect(screen.getByText('Tout sélectionner (10)')).toBeInTheDocument();
   });
+
+  test('should disable Select none when nothing is selected', async () => {
+    const user = userEvent.setup();
+    render(
+      <BulkSelect
+        canSelectAll
+        pageCount={5}
+        totalCount={10}
+        selectedCount={0}
+        pageSelected={false}
+        pagePartiallySelected={false}
+        onSelect={() => null}
+      />
+    );
+
+    await user.click(screen.getByLabelText('Bulk select toggle'));
+    expect(screen.getByRole('menuitem', { name: 'Select none (0)' })).toBeDisabled();
+  });
+
+  test('should enable Select none when at least one row is selected', async () => {
+    const user = userEvent.setup();
+    render(
+      <BulkSelect
+        canSelectAll
+        pageCount={5}
+        totalCount={10}
+        selectedCount={1}
+        pageSelected={false}
+        pagePartiallySelected={true}
+        onSelect={() => null}
+      />
+    );
+
+    await user.click(screen.getByLabelText('Bulk select toggle'));
+    expect(screen.getByRole('menuitem', { name: 'Select none (0)' })).not.toBeDisabled();
+  });
 });

--- a/packages/module/src/BulkSelect/BulkSelect.tsx
+++ b/packages/module/src/BulkSelect/BulkSelect.tsx
@@ -88,7 +88,12 @@ export const BulkSelect: FC<BulkSelectProps> = ({
   const splitButtonDropdownItems = useMemo(
     () => (
       <>
-        <DropdownItem ouiaId={`${ouiaId}-select-none`} value={BulkSelectValue.none} key={BulkSelectValue.none}>
+        <DropdownItem
+          ouiaId={`${ouiaId}-select-none`}
+          value={BulkSelectValue.none}
+          key={BulkSelectValue.none}
+          isDisabled={selectedCount === 0}
+        >
           {selectNoneLabel}
         </DropdownItem>
         {isDataPaginated && (
@@ -103,7 +108,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
         )}
       </>
     ),
-    [ isDataPaginated, canSelectAll, ouiaId, selectNoneLabel, selectPageLabel, selectAllLabel, pageCount, totalCount ]
+    [ isDataPaginated, canSelectAll, ouiaId, selectNoneLabel, selectPageLabel, selectAllLabel, pageCount, totalCount, selectedCount ]
   );
 
   const selectedLabelText = selectedLabel(selectedCount);


### PR DESCRIPTION
Hey, 

I'd like to propose change, that disable _Select none(0)_ option in dropdown menu of BulkSelect when nothing is selected. 

Why?
We're trying to follow through on UX guidelines which were acknowledged by Patternfly team as well at: https://github.com/issues/recent?issue=patternfly%7Cpatternfly-org%7C4620

Current BulkSelect API doesn't allow us to do this from the outside hence the change. 

Let me know what you think.
