### PR TITLE
feat(ColumnManagementModal): add support for extended columns

### DIFF
--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
@@ -1,9 +1,9 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ColumnManagementModal, { ColumnManagementModalColumn } from './ColumnManagementModal';
 
-const DEFAULT_COLUMNS : ColumnManagementModalColumn[] = [
+const DEFAULT_COLUMNS: ColumnManagementModalColumn[] = [
   {
     title: 'ID',
     key: 'id',
@@ -37,17 +37,20 @@ const setColumns = jest.fn();
 // Simple mock to track when DragDropSort is used
 jest.mock('@patternfly/react-drag-drop', () => ({
   DragDropSort: ({ children }) => <div data-testid="drag-drop-sort">{children}</div>,
-  Droppable: ({ wrapper }) => wrapper,
+  Droppable: ({ wrapper }) => wrapper
 }));
 
-const renderColumnManagementModal = (props = {}) => render(<ColumnManagementModal
-  appliedColumns={DEFAULT_COLUMNS}
-  applyColumns={newColumns => setColumns(newColumns)}
-  isOpen
-  onClose={onClose}
-  data-testid="column-mgmt-modal"
-  {...props}
-/>);
+const renderColumnManagementModal = (props = {}) =>
+  render(
+    <ColumnManagementModal
+      appliedColumns={DEFAULT_COLUMNS}
+      applyColumns={(newColumns) => setColumns(newColumns)}
+      isOpen
+      onClose={onClose}
+      data-testid="column-mgmt-modal"
+      {...props}
+    />
+  );
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -56,17 +59,21 @@ beforeEach(() => {
 
 const getCheckboxesState = () => {
   // Get only the column checkboxes (exclude the BulkSelect checkbox)
-  const checkboxes = screen.getByTestId('column-mgmt-modal').querySelectorAll('input[type="checkbox"][data-testid^="column-check-"]');
-  return (Array.from(checkboxes) as HTMLInputElement[]).map(c => c.checked);
-}
+  const checkboxes = screen
+    .getByTestId('column-mgmt-modal')
+    .querySelectorAll('input[type="checkbox"][data-testid^="column-check-"]');
+  return (Array.from(checkboxes) as HTMLInputElement[]).map((c) => c.checked);
+};
 
 describe('ColumnManagementModal component', () => {
   it('should have disabled and checked checkboxes for columns that should always be shown', () => {
-    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map(c => c.isShownByDefault));
+    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map((c) => c.isShownByDefault));
   });
 
   it('should have checkbox checked if column is shown by default', () => {
-    const idCheckbox = screen.getByTestId('column-mgmt-modal').querySelector('input[type="checkbox"][data-testid="column-check-id"]');
+    const idCheckbox = screen
+      .getByTestId('column-mgmt-modal')
+      .querySelector('input[type="checkbox"][data-testid="column-check-id"]');
 
     expect(idCheckbox).toHaveAttribute('disabled');
     expect(idCheckbox).toHaveAttribute('checked');
@@ -81,18 +88,20 @@ describe('ColumnManagementModal component', () => {
 
     fireEvent.click(screen.getByText('Reset to default'));
 
-    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map(c => c.isShownByDefault));
+    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map((c) => c.isShownByDefault));
   });
 
   it('should call onReset callback when reset to default is clicked', () => {
     const onResetMock = jest.fn();
-    render(<ColumnManagementModal
-      appliedColumns={DEFAULT_COLUMNS}
-      applyColumns={setColumns}
-      isOpen
-      onClose={onClose}
-      onReset={onResetMock}
-    />);
+    render(
+      <ColumnManagementModal
+        appliedColumns={DEFAULT_COLUMNS}
+        applyColumns={setColumns}
+        isOpen
+        onClose={onClose}
+        onReset={onResetMock}
+      />
+    );
 
     const resetButtons = screen.getAllByText('Reset to default');
     // Click the last one rendered (the new modal)
@@ -103,13 +112,15 @@ describe('ColumnManagementModal component', () => {
 
   it('should display custom reset button label', () => {
     const customLabel = 'Restaurer par défaut';
-    render(<ColumnManagementModal
-      appliedColumns={DEFAULT_COLUMNS}
-      applyColumns={setColumns}
-      isOpen
-      onClose={onClose}
-      resetToDefaultLabel={customLabel}
-    />);
+    render(
+      <ColumnManagementModal
+        appliedColumns={DEFAULT_COLUMNS}
+        applyColumns={setColumns}
+        isOpen
+        onClose={onClose}
+        resetToDefaultLabel={customLabel}
+      />
+    );
 
     expect(screen.getByText(customLabel)).toBeInTheDocument();
   });
@@ -124,7 +135,7 @@ describe('ColumnManagementModal component', () => {
     const selectAllButton = screen.getByText('Select all (4)');
     await userEvent.click(selectAllButton);
 
-    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map(_ => true));
+    expect(getCheckboxesState()).toEqual(DEFAULT_COLUMNS.map((_) => true));
   });
 
   it('should change columns on save', () => {
@@ -132,7 +143,7 @@ describe('ColumnManagementModal component', () => {
     fireEvent.click(screen.getByText('Save'));
 
     const expectedColumns = DEFAULT_COLUMNS;
-    const impactColumn = expectedColumns.find(c => c.title === 'Impact');
+    const impactColumn = expectedColumns.find((c) => c.title === 'Impact');
 
     if (impactColumn === undefined) {
       throw new Error('Expected to find "Impact" column in "DEFAULT_COLUMNS"');
@@ -175,16 +186,18 @@ describe('ColumnManagementModal component', () => {
         DEFAULT_COLUMNS[3], // Score (last -> first)
         DEFAULT_COLUMNS[0], // ID
         DEFAULT_COLUMNS[2], // Impact
-        DEFAULT_COLUMNS[1], // Publish date
+        DEFAULT_COLUMNS[1] // Publish date
       ];
 
       const applyColumnsMock = jest.fn();
-      render(<ColumnManagementModal
-        appliedColumns={reorderedColumns}
-        applyColumns={applyColumnsMock}
-        isOpen
-        onClose={onClose}
-      />);
+      render(
+        <ColumnManagementModal
+          appliedColumns={reorderedColumns}
+          applyColumns={applyColumnsMock}
+          isOpen
+          onClose={onClose}
+        />
+      );
 
       // Click reset to default - get all buttons and click the last one
       const resetButtons = screen.getAllByText('Reset to default');
@@ -197,7 +210,7 @@ describe('ColumnManagementModal component', () => {
       // Verify that the saved columns match the original reordered columns order
       // (after reset, it should restore the order from appliedColumns which is reorderedColumns)
       expect(applyColumnsMock).toHaveBeenCalledWith(
-        reorderedColumns.map(col => ({
+        reorderedColumns.map((col) => ({
           ...col,
           isShown: col.isShownByDefault
         }))

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ColumnManagementModal, { ColumnManagementModalColumn } from './ColumnManagementModal';
 
@@ -30,6 +30,15 @@ const DEFAULT_COLUMNS: ColumnManagementModalColumn[] = [
     isShown: false
   }
 ];
+
+interface ExtendedColumn extends ColumnManagementModalColumn {
+  dataKey: string;
+}
+
+const EXTENDED_COLUMNS: ExtendedColumn[] = DEFAULT_COLUMNS.map((col) => ({
+  ...col,
+  dataKey: `row.${col.key}`
+}));
 
 const onClose = jest.fn();
 const setColumns = jest.fn();
@@ -162,6 +171,35 @@ describe('ColumnManagementModal component', () => {
     expect(onClose).toHaveBeenCalled();
     // applyColumns should NOT be called on cancel
     expect(setColumns).not.toHaveBeenCalled();
+  });
+
+  it('should preserve extended column fields when saving', () => {
+    const applyColumnsMock = jest.fn();
+    render(
+      <ColumnManagementModal<ExtendedColumn>
+        appliedColumns={EXTENDED_COLUMNS}
+        applyColumns={applyColumnsMock}
+        isOpen
+        onClose={onClose}
+        data-testid="extended-column-modal"
+      />
+    );
+
+    const modal = screen.getByTestId('extended-column-modal');
+    fireEvent.click(within(modal).getByTestId('column-check-impact'));
+    fireEvent.click(within(modal).getByRole('button', { name: 'Save' }));
+
+    expect(applyColumnsMock).toHaveBeenCalledTimes(1);
+    const saved = applyColumnsMock.mock.calls[0][0] as ExtendedColumn[];
+
+    // Test that we have same number of columns
+    expect(saved).toHaveLength(EXTENDED_COLUMNS.length);
+
+    // Test that extension keys were preserved
+    saved.forEach((col) => {
+      const source = EXTENDED_COLUMNS.find((aec) => aec.key === col.key);
+      expect(source?.dataKey).toBe(col.dataKey);
+    });
   });
 
   describe('enableDragDrop prop', () => {

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -1,11 +1,6 @@
 import type { FunctionComponent } from 'react';
 import { useState, useEffect } from 'react';
-import {
-  Button,
-  Content,
-  ContentVariants,
-  ButtonVariant,
-} from '@patternfly/react-core';
+import { Button, Content, ContentVariants, ButtonVariant } from '@patternfly/react-core';
 import { ModalProps, Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import ListManager, { ListManagerItem } from '../ListManager/ListManager';
 
@@ -46,30 +41,32 @@ export interface ColumnManagementModalProps extends Omit<ModalProps, 'ref' | 'ch
   resetToDefaultLabel?: string;
 }
 
-const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = (
-  { title = 'Manage columns',
-    description = 'Selected categories will be displayed in the table.',
-    isOpen = false,
-    onClose = () => undefined,
-    appliedColumns,
-    applyColumns,
-    ouiaId = 'ColumnManagementModal',
-    enableDragDrop = false,
-    onReset,
-    resetToDefaultLabel = 'Reset to default',
-    ...props }: ColumnManagementModalProps) => {
-
+const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = ({
+  title = 'Manage columns',
+  description = 'Selected categories will be displayed in the table.',
+  isOpen = false,
+  onClose = () => undefined,
+  appliedColumns,
+  applyColumns,
+  ouiaId = 'ColumnManagementModal',
+  enableDragDrop = false,
+  onReset,
+  resetToDefaultLabel = 'Reset to default',
+  ...props
+}: ColumnManagementModalProps) => {
   const [ currentColumns, setCurrentColumns ] = useState(() =>
-    appliedColumns.map(column => ({ ...column, isShown: column.isShown ?? column.isShownByDefault }))
+    appliedColumns.map((column) => ({ ...column, isShown: column.isShown ?? column.isShownByDefault }))
   );
 
   // Sync with appliedColumns when they change
   useEffect(() => {
-    setCurrentColumns(appliedColumns.map(column => ({ ...column, isShown: column.isShown ?? column.isShownByDefault })));
+    setCurrentColumns(
+      appliedColumns.map((column) => ({ ...column, isShown: column.isShown ?? column.isShownByDefault }))
+    );
   }, [ appliedColumns ]);
 
   // Convert ColumnManagementModalColumn to ListManagerItem
-  const listManagerItems: ListManagerItem[] = currentColumns.map(column => ({
+  const listManagerItems: ListManagerItem[] = currentColumns.map((column) => ({
     key: column.key,
     title: column.title,
     isSelected: column.isShown,
@@ -79,16 +76,14 @@ const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = (
 
   const resetToDefault = () => {
     // Reset both visibility and order to match the original appliedColumns
-    setCurrentColumns(appliedColumns.map(column => ({ ...column, isShown: column.isShownByDefault ?? false })));
+    setCurrentColumns(appliedColumns.map((column) => ({ ...column, isShown: column.isShownByDefault ?? false })));
     onReset?.();
   };
 
   const updateColumns = (items: ListManagerItem[]) => {
-    const newColumns = currentColumns.map(column => {
-      const matchingItem = items.find(item => item.key === column.key);
-      return matchingItem
-        ? { ...column, isShown: matchingItem.isSelected ?? column.isShownByDefault }
-        : column;
+    const newColumns = currentColumns.map((column) => {
+      const matchingItem = items.find((item) => item.key === column.key);
+      return matchingItem ? { ...column, isShown: matchingItem.isSelected ?? column.isShownByDefault } : column;
     });
     setCurrentColumns(newColumns);
   };
@@ -103,8 +98,8 @@ const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = (
 
   const handleOrderChange = (items: ListManagerItem[]) => {
     // Update the order of currentColumns based on the new order from ListManager
-    const newColumns = items.map(item => {
-      const originalColumn = currentColumns.find(col => col.key === item.key);
+    const newColumns = items.map((item) => {
+      const originalColumn = currentColumns.find((col) => col.key === item.key);
       if (!originalColumn) {
         throw new Error(`Column with key ${item.key} not found`);
       }
@@ -114,7 +109,7 @@ const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = (
   };
 
   const handleSave = (items: ListManagerItem[]) => {
-    const updatedColumns = items.map(item => ({
+    const updatedColumns = items.map((item) => ({
       key: item.key,
       title: item.title,
       isShown: item.isSelected,
@@ -158,6 +153,6 @@ const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = (
       />
     </Modal>
   );
-}
+};
 
 export default ColumnManagementModal;

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -17,7 +17,8 @@ export interface ColumnManagementModalColumn {
 }
 
 /** extends ModalProps */
-export interface ColumnManagementModalProps<T extends ColumnManagementModalColumn = ColumnManagementModalColumn> extends Omit<ModalProps, 'ref' | 'children'> {
+export interface ColumnManagementModalProps<T extends ColumnManagementModalColumn = ColumnManagementModalColumn>
+  extends Omit<ModalProps, 'ref' | 'children'> {
   /** Flag to show the modal */
   isOpen?: boolean;
   /** Invoked when modal visibility is changed */
@@ -53,7 +54,7 @@ const ColumnManagementModal = <T extends ColumnManagementModalColumn = ColumnMan
   resetToDefaultLabel = 'Reset to default',
   ...props
 }: ColumnManagementModalProps<T>) => {
-  const [ currentColumns, setCurrentColumns ] = useState(() =>
+  const [ currentColumns, setCurrentColumns ] = useState<T[]>(() =>
     appliedColumns.map((column) => ({ ...column, isShown: column.isShown ?? column.isShownByDefault }))
   );
 
@@ -108,13 +109,13 @@ const ColumnManagementModal = <T extends ColumnManagementModalColumn = ColumnMan
   };
 
   const handleSave = (items: ListManagerItem[]) => {
-    const updatedColumns = items.map((item) => ({
-      key: item.key,
-      title: item.title,
-      isShown: item.isSelected,
-      isShownByDefault: item.isShownByDefault,
-      isUntoggleable: item.isUntoggleable
-    }));
+    const updatedColumns = items.map((item) => {
+      const originalColumn = currentColumns.find((col) => col.key === item.key);
+      if (!originalColumn) {
+        throw new Error(`Column with key ${item.key} not found`);
+      }
+      return { ...originalColumn, isShown: item.isSelected };
+    });
     applyColumns(updatedColumns);
     onClose({} as KeyboardEvent);
   };

--- a/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { useState, useEffect } from 'react';
 import { Button, Content, ContentVariants, ButtonVariant } from '@patternfly/react-core';
 import { ModalProps, Modal, ModalVariant } from '@patternfly/react-core/deprecated';
@@ -18,15 +17,15 @@ export interface ColumnManagementModalColumn {
 }
 
 /** extends ModalProps */
-export interface ColumnManagementModalProps extends Omit<ModalProps, 'ref' | 'children'> {
+export interface ColumnManagementModalProps<T extends ColumnManagementModalColumn = ColumnManagementModalColumn> extends Omit<ModalProps, 'ref' | 'children'> {
   /** Flag to show the modal */
   isOpen?: boolean;
   /** Invoked when modal visibility is changed */
   onClose?: (event: KeyboardEvent | React.MouseEvent) => void;
   /** Current column state */
-  appliedColumns: ColumnManagementModalColumn[];
+  appliedColumns: T[];
   /** Invoked with new column state after save button is clicked */
-  applyColumns: (newColumns: ColumnManagementModalColumn[]) => void;
+  applyColumns: (newColumns: T[]) => void;
   /* Modal description text */
   description?: string;
   /* Modal title text */
@@ -41,7 +40,7 @@ export interface ColumnManagementModalProps extends Omit<ModalProps, 'ref' | 'ch
   resetToDefaultLabel?: string;
 }
 
-const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = ({
+const ColumnManagementModal = <T extends ColumnManagementModalColumn = ColumnManagementModalColumn>({
   title = 'Manage columns',
   description = 'Selected categories will be displayed in the table.',
   isOpen = false,
@@ -53,7 +52,7 @@ const ColumnManagementModal: FunctionComponent<ColumnManagementModalProps> = ({
   onReset,
   resetToDefaultLabel = 'Reset to default',
   ...props
-}: ColumnManagementModalProps) => {
+}: ColumnManagementModalProps<T>) => {
   const [ currentColumns, setCurrentColumns ] = useState(() =>
     appliedColumns.map((column) => ({ ...column, isShown: column.isShown ?? column.isShownByDefault }))
   );


### PR DESCRIPTION
Hey, 

I've extended Modal so it supports subtype of ColumnManagementModalColumn, once this is applied we'll be able to pass in our custom Column type which extends ColumnManagementModalColumn and get the same custom columns back.

### What this PR do?

ColumnManagementModal now fully works with custom shape columns which are subtype of [ColumnManagementModalColumn](https://github.com/patternfly/react-component-groups/blob/0da4098e8407657202e785c89b1886675e822f08/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx#L12)

### Why we need this?

- Modal can be passed custom column objects, but it only returns column objects with rigid structure and strips any extra properties. 
- This is introducing complexity downstream, as we basically have to maintain two column structures, one for modal and one of our own and transform between them.

### How we are fixing it?

- ColumnManagementModal becomes generic over a column type that extends ColumnManagementModalColumn. 
- Modal passes back the same column objects we passed in, with only isShown updated, instead of rebuilding rows from ListManagerItem (which only recreated a subset of fields passed in).

### API compatibilty concerns

- Change is backward compatible
- We don't do any changes in prop names nor runtime defaults
- Type level: There is just extra capability and un-parameterized usage still defaults to ColumnManagementModalColumn
- applyColumns now receives full column objects. Previously, save dropped extra properties. That would be incompatible only if something relied on those extras being removed at save time for typical usage this is a bugfix and improves compatibility