### PR TITLE
fix: remove doubled spacing between drag handle and checkbox

### DIFF
--- a/packages/module/src/ListManager/ListManager.test.tsx
+++ b/packages/module/src/ListManager/ListManager.test.tsx
@@ -84,6 +84,19 @@ describe('ListManager', () => {
   });
 
   describe('enableDragDrop prop', () => {
+    it('places checkboxes in DataListControl so they share spacing with the drag handle', () => {
+      render(<ListManager columns={mockColumns} />);
+      const checkbox = screen.getByTestId('column-check-name');
+      expect(checkbox.closest('.pf-v6-c-data-list__item-control')).toBeInTheDocument();
+      expect(checkbox.closest('.pf-v6-c-data-list__item-row')).not.toBeInTheDocument();
+    });
+
+    it('keeps non-draggable rows in DataListItemRow', () => {
+      render(<ListManager columns={mockColumns} enableDragDrop={false} />);
+      const checkbox = screen.getByTestId('column-check-name');
+      expect(checkbox.closest('.pf-v6-c-data-list__item-row')).toBeInTheDocument();
+    });
+
     it('should sync columns when props change', async () => {
       const { rerender } = render(<ListManager columns={mockColumns} enableDragDrop={false} />);
 

--- a/packages/module/src/ListManager/ListManager.tsx
+++ b/packages/module/src/ListManager/ListManager.tsx
@@ -5,6 +5,7 @@ import {
   DataListItem,
   DataListItemRow,
   DataListCheck,
+  DataListControl,
   DataListCell,
   DataListItemCells,
   Button,
@@ -111,27 +112,45 @@ const ListManager: FunctionComponent<ListManagerProps> = (
     onSelectAll?.(newColumns);
   };
 
+  const renderColumnCheck = (column: ListManagerItem & { id: string }, index: number, otherControls = false) => (
+    <DataListCheck
+      data-testid={`column-check-${column.key}`}
+      otherControls={otherControls}
+      isChecked={column.isSelected}
+      onChange={() => handleChange(column.key)}
+      isDisabled={column.isUntoggleable}
+      ouiaId={`${ouiaId}-column-${index}-checkbox`}
+      id={`${ouiaId}-column-${index}-checkbox`}
+      aria-labelledby={`${ouiaId}-column-${index}-label`}
+    />
+  );
+
+  const renderColumnCells = (column: ListManagerItem & { id: string }, index: number) => (
+    <DataListItemCells
+      dataListCells={[
+        <DataListCell key={column.key} data-ouia-component-id={`${ouiaId}-column-${index}-label`}>
+          <label htmlFor={`${ouiaId}-column-${index}-checkbox`}>
+            {column.title}
+          </label>
+        </DataListCell>
+      ]}
+    />
+  );
+
   const renderDataListItem = (column: ListManagerItem & { id: string }, index: number) => (
     <DataListItemRow key={column.key}>
-      <DataListCheck
-        data-testid={`column-check-${column.key}`}
-        isChecked={column.isSelected}
-        onChange={() => handleChange(column.key)}
-        isDisabled={column.isUntoggleable}
-        ouiaId={`${ouiaId}-column-${index}-checkbox`}
-        id={`${ouiaId}-column-${index}-checkbox`}
-        aria-labelledby={`${ouiaId}-column-${index}-label`}
-      />
-      <DataListItemCells
-        dataListCells={[
-          <DataListCell key={column.key} data-ouia-component-id={`${ouiaId}-column-${index}-label`}>
-            <label htmlFor={`${ouiaId}-column-${index}-checkbox`}>
-              {column.title}
-            </label>
-          </DataListCell>
-        ]}
-      />
+      {renderColumnCheck(column, index)}
+      {renderColumnCells(column, index)}
     </DataListItemRow>
+  );
+
+  const renderDraggableDataListItem = (column: ListManagerItem & { id: string }, index: number) => (
+    <>
+      <DataListControl>
+        {renderColumnCheck(column, index, true)}
+      </DataListControl>
+      {renderColumnCells(column, index)}
+    </>
   );
 
   return (
@@ -152,7 +171,7 @@ const ListManager: FunctionComponent<ListManagerProps> = (
       {enableDragDrop ? (
         <DragDropSort
           variant="DataList"
-          items={currentColumns.map((column, index) => ({ id: column.key, content: renderDataListItem(column, index) }))}
+          items={currentColumns.map((column, index) => ({ id: column.key, content: renderDraggableDataListItem(column, index) }))}
           onDrop={onDrag}
           overlayProps={{ isCompact: true }}
         >


### PR DESCRIPTION
Hi guys

we've had problems with extra padding in columnManagementModal between drag & drop handle and checkbox. It seems to be caused by a wrong markup in ListManager. This PR solves that. 

What
Remove extra spacing between the drag handle and checkbox in ListManager when drag-and-drop is enabled.

Why (AI)
DragDropSort already wraps each row in DataListItemRow and injects a drag-handle DataListControl. ListManager was wrapping the same content in a second DataListItemRow and a DataListCheck without otherControls, so PatternFly applied extra row padding between the handle and the checkbox.

How (AI)
Render drag-drop rows with PatternFly’s draggable DataList structure: checkbox inside DataListControl with otherControls={true}, and leave non-draggable rows on DataListItemRow. Tests cover both layouts.