### PR TITLE
fix(TagCount): fix icon color in dark theme

### DIFF
--- a/packages/module/src/TagCount/TagCount.tsx
+++ b/packages/module/src/TagCount/TagCount.tsx
@@ -12,7 +12,7 @@ const useStyles = createUseStyles({
   },
 
   tagIcon: (isDisabled: boolean) => ({
-    color: `var(--pf-t--global--icon--color--${isDisabled ? '200' : '100'})`,
+    color: isDisabled ? 'var(--pf-t--global--icon--color--disabled)' : 'var(--pf-v6-c-button__icon--Color)',
   }),
 
   tagText: {


### PR DESCRIPTION
HMS-11250

Icon colors are hard-coded for light theme. It is an accessibility and style issue.